### PR TITLE
Fix parsing RIFL file and serialize category into the XML output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ soot-infoflow-summaries/build/
 soot-infoflow-summaries/target/
 /.metadata
 /.recommenders
+.idea/
+*.iml

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/source/AndroidSourceSinkManager.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/source/AndroidSourceSinkManager.java
@@ -919,30 +919,25 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 */
 	private SootMethod grabMethodWithoutReturn(String sootClassName, String subSignature)
 	{
-		Scene scene=Scene.v();
-		if(!scene.containsClass(sootClassName))
-			return null;
-		SootClass sootClass=Scene.v().getSootClass(sootClassName);
-
-		/*SootClass sootClass=Scene.v().getSootClassUnsafe(sootClassName);
+		SootClass sootClass=Scene.v().getSootClassUnsafe(sootClassName);
 		if(sootClass==null)
-			return null;*/
+			return null;
 
 		List<SootMethod> sootMethods=null;
+		if(sootClass.resolvingLevel()!=0) {
+			sootMethods = sootClass.getMethods();
 
-		sootMethods = sootClass.getMethods();
+			for (SootMethod s : sootMethods) {
+				String[] tempSignature = s.getSubSignature().split(" ");
 
-		for (SootMethod s: sootMethods)
-		{
-			String[] tempSignature=s.getSubSignature().split(" ");
+				if (tempSignature.length == 2) {
+					if (tempSignature[1].equals(subSignature))
+						return s;
+				}
 
-			if(tempSignature.length==2)
-			{
-				if(tempSignature[1].equals(subSignature))
-					return s;
 			}
-
 		}
+
 		return null;
 	}
 

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/source/AndroidSourceSinkManager.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/source/AndroidSourceSinkManager.java
@@ -78,6 +78,8 @@ import soot.jimple.toolkits.scalar.ConstantPropagatorAndFolder;
 import soot.tagkit.IntegerConstantValueTag;
 import soot.tagkit.Tag;
 
+import static soot.SootClass.DANGLING;
+
 /**
  * SourceManager implementation for AndroidSources
  *
@@ -924,7 +926,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 			return null;
 
 		List<SootMethod> sootMethods=null;
-		if(sootClass.resolvingLevel()!=0) {
+		if(sootClass.resolvingLevel()!=DANGLING) {
 			sootMethods = sootClass.getMethods();
 
 			for (SootMethod s : sootMethods) {

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/source/AndroidSourceSinkManager.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/source/AndroidSourceSinkManager.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the GNU Lesser Public License v2.1
  * which accompanies this distribution, and is available at
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * 
+ *
  * Contributors: Christian Fritz, Steven Arzt, Siegfried Rasthofer, Eric
  * Bodden, and others.
  ******************************************************************************/
@@ -58,6 +58,7 @@ import soot.jimple.infoflow.android.resources.ARSCFileParser.ResPackage;
 import soot.jimple.infoflow.android.resources.controls.LayoutControl;
 import soot.jimple.infoflow.data.AccessPath;
 import soot.jimple.infoflow.data.AccessPath.ArrayTaintType;
+import soot.jimple.infoflow.data.SootMethodAndClass;
 import soot.jimple.infoflow.entryPointCreators.android.AndroidEntryPointUtils;
 import soot.jimple.infoflow.solver.cfg.IInfoflowCFG;
 import soot.jimple.infoflow.sourcesSinks.definitions.AccessPathTuple;
@@ -79,7 +80,7 @@ import soot.tagkit.Tag;
 
 /**
  * SourceManager implementation for AndroidSources
- * 
+ *
  * @author Steven Arzt
  */
 public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceAtATimeManager {
@@ -88,7 +89,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Types of sources supported by this SourceSinkManager
-	 * 
+	 *
 	 * @author Steven Arzt
 	 */
 	public static enum SourceType {
@@ -162,7 +163,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Creates a new instance of the {@link AndroidSourceSinkManager} class with
 	 * either strong or weak matching.
-	 * 
+	 *
 	 * @param sources
 	 *            The list of source methods
 	 * @param sinks
@@ -171,7 +172,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 *            The configuration of the data flow analyzer
 	 */
 	public AndroidSourceSinkManager(Set<SourceSinkDefinition> sources, Set<SourceSinkDefinition> sinks,
-			InfoflowAndroidConfiguration config) {
+									InfoflowAndroidConfiguration config) {
 		this(sources, sinks, Collections.<CallbackDefinition>emptySet(), config, null);
 	}
 
@@ -179,7 +180,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 * Creates a new instance of the {@link AndroidSourceSinkManager} class with
 	 * strong matching, i.e. the methods in the code must exactly match those in the
 	 * list.
-	 * 
+	 *
 	 * @param sources
 	 *            The list of source methods
 	 * @param sinks
@@ -199,8 +200,8 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 *            controls
 	 */
 	public AndroidSourceSinkManager(Set<SourceSinkDefinition> sources, Set<SourceSinkDefinition> sinks,
-			Set<CallbackDefinition> callbackMethods, InfoflowAndroidConfiguration config,
-			Map<Integer, LayoutControl> layoutControls) {
+									Set<CallbackDefinition> callbackMethods, InfoflowAndroidConfiguration config,
+									Map<Integer, LayoutControl> layoutControls) {
 		this.sourceSinkConfig = config.getSourceSinkConfig();
 
 		this.sourceDefs = new HashMap<>();
@@ -223,7 +224,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Gets the field or method signature of the given source/sink definition
-	 * 
+	 *
 	 * @param am
 	 *            The source/sink definition for which to get a Soot signature
 	 * @return The Soot signature associated with the given source/sink definition
@@ -242,7 +243,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Gets the sink definition for the given call site and tainted access path
-	 * 
+	 *
 	 * @param sCallSite
 	 *            The call site
 	 * @param manager
@@ -340,7 +341,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 * Scans the hierarchy of the class containing the given method to find any
 	 * implementations of the same method further up in the hierarchy for which
 	 * there is a SourceSinkDefinition in the given map
-	 * 
+	 *
 	 * @param callee
 	 *            The method for which to look for a SourceSinkDefinition
 	 * @param map
@@ -349,7 +350,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 *         somewhere up in the class hiearchy if it exists, otherwise null.
 	 */
 	private static SourceSinkDefinition findDefinitionInHierarchy(SootMethod callee,
-			Map<SootMethod, SourceSinkDefinition> map) {
+																  Map<SootMethod, SourceSinkDefinition> map) {
 		final String subSig = callee.getSubSignature();
 		SootClass curClass = callee.getDeclaringClass();
 		while (curClass != null) {
@@ -425,7 +426,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Checks whether the given method is registered as a source method. If so,
 	 * returns the corresponding definition, otherwise null.
-	 * 
+	 *
 	 * @param method
 	 *            The method to check
 	 * @return The respective source definition if the given method is a source
@@ -439,7 +440,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Checks whether the given method is registered as a source method
-	 * 
+	 *
 	 * @param method
 	 *            The method to check
 	 * @return True if the given method is a source method, otherwise false
@@ -457,7 +458,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Checks whether the given method is registered as a callback method. If so,
 	 * the corresponding source definition is returned, otherwise null is returned.
-	 * 
+	 *
 	 * @param method
 	 *            The method to check
 	 * @return The source definition object if the given method is a callback
@@ -477,7 +478,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 * Checks whether the given statement is a source, i.e. introduces new
 	 * information into the application. If so, the source definition is returned,
 	 * otherwise null
-	 * 
+	 *
 	 * @param sCallSite
 	 *            The statement to check for a source
 	 * @param cfg
@@ -549,7 +550,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Checks whether the given statement accesses a field that has been marked as a
 	 * source
-	 * 
+	 *
 	 * @param stmt
 	 *            The statement to check
 	 * @param cfg
@@ -570,7 +571,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Checks whether the given statement obtains data from a callback source
-	 * 
+	 *
 	 * @param sCallSite
 	 *            The statement to check
 	 * @param cfg
@@ -641,7 +642,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Checks whether the given call site indicates a UI source, e.g. a password
 	 * input. If so, creates a {@link SourceSinkDefinition} for it
-	 * 
+	 *
 	 * @param sCallSite
 	 *            The call site that may potentially read data from a sensitive UI
 	 *            control
@@ -735,7 +736,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Finds the last assignment to the given local representing a resource ID by
 	 * searching upwards from the given statement
-	 * 
+	 *
 	 * @param stmt
 	 *            The statement from which to look backwards
 	 * @param local
@@ -743,7 +744,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	 * @return The last value assigned to the given variable
 	 */
 	private Integer findLastResIDAssignment(Stmt stmt, Local local, BiDiInterproceduralCFG<Unit, SootMethod> cfg,
-			Set<Stmt> doneSet) {
+											Set<Stmt> doneSet) {
 		if (!doneSet.add(stmt))
 			return null;
 
@@ -817,7 +818,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Finds the given resource in the given package
-	 * 
+	 *
 	 * @param resName
 	 *            The name of the resource to retrieve
 	 * @param resID
@@ -849,7 +850,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Finds the last assignment to the given String local by searching upwards from
 	 * the given statement
-	 * 
+	 *
 	 * @param stmt
 	 *            The statement from which to look backwards
 	 * @param local
@@ -888,7 +889,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Sets the resource packages to be used for finding sensitive layout controls
 	 * as sources
-	 * 
+	 *
 	 * @param resourcePackages
 	 *            The resource packages to be used for looking up layout controls
 	 */
@@ -898,7 +899,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 
 	/**
 	 * Sets the name of the app's base package
-	 * 
+	 *
 	 * @param appPackageName
 	 *            The name of the app's base package
 	 */
@@ -906,17 +907,30 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 		this.appPackageName = appPackageName;
 	}
 
-	private SootMethod grabMethod(String sootClassName,String subSignature)
+	/**
+	 * Gets a soot method defined by class name and its sub signature
+	 * from the loaded methods in the Scene object
+	 *
+	 * @param sootClassName
+	 *            The class name of the method
+	 * @param subSignature
+	 *            The sub signature of the method which is the method name and its parameters
+	 * @return The soot method of the given class and sub signature or null
+	 */
+	private SootMethod grabMethodWithoutReturn(String sootClassName, String subSignature)
 	{
 		Scene scene=Scene.v();
 		if(!scene.containsClass(sootClassName))
 			return null;
-		SootClass sootClass=scene.getSootClass(sootClassName);
+		SootClass sootClass=Scene.v().getSootClass(sootClassName);
 
+		/*SootClass sootClass=Scene.v().getSootClassUnsafe(sootClassName);
+		if(sootClass==null)
+			return null;*/
 
 		List<SootMethod> sootMethods=null;
 
-		sootMethods= sootClass.getMethods();
+		sootMethods = sootClass.getMethods();
 
 		for (SootMethod s: sootMethods)
 		{
@@ -941,18 +955,25 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 			for (Entry<String, SourceSinkDefinition> entry : sourceDefs.entrySet()) {
 				SourceSinkDefinition sourceSinkDef = entry.getValue();
 				if (sourceSinkDef instanceof MethodSourceSinkDefinition) {
-					SootMethod sm = Scene.v().grabMethod(entry.getKey());
-
-					if (sm != null)
-						sourceMethods.put(sm, sourceSinkDef);
-					else{ //in case method signature doesn't contain return type
-						String className=((MethodSourceSinkDefinition) sourceSinkDef).getMethod().getClassName();
+					SootMethodAndClass method=((MethodSourceSinkDefinition) sourceSinkDef).getMethod();
+					String returnType=method.getReturnType();
+					boolean isMethodWithoutReturnType=	returnType==null||returnType.isEmpty();
+					if(isMethodWithoutReturnType)
+					{
+						String className=method.getClassName();
 
 						String subSignatureWithoutReturnType=(((MethodSourceSinkDefinition) sourceSinkDef).getMethod().getSubSignature());
-						SootMethod sootMethod=	grabMethod(className,subSignatureWithoutReturnType);
+						SootMethod sootMethod=	grabMethodWithoutReturn(className,subSignatureWithoutReturnType);
 						if(sootMethod!=null)
 							sourceMethods.put(sootMethod, sourceSinkDef);
 					}
+					else
+					{
+						SootMethod sm = Scene.v().grabMethod(entry.getKey());
+						if (sm != null)
+							sourceMethods.put(sm, sourceSinkDef);
+					}
+
 				} else if (sourceSinkDef instanceof FieldSourceSinkDefinition) {
 					SootField sf = Scene.v().grabField(entry.getKey());
 					if (sf != null)
@@ -969,17 +990,25 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 			sinkFields = new HashMap<>();
 			for (Entry<String, SourceSinkDefinition> entry : sinkDefs.entrySet()) {
 				SourceSinkDefinition sourceSinkDef = entry.getValue();
-				if (sourceSinkDef instanceof MethodSourceSinkDefinition) {
-					SootMethod sm = Scene.v().grabMethod(entry.getKey());
-					if (sm != null)
-						sinkMethods.put(sm, entry.getValue());
-					else{//in case method signature doesn't contain return type
-						String className=((MethodSourceSinkDefinition) sourceSinkDef).getMethod().getClassName();
+				if (sourceSinkDef instanceof MethodSourceSinkDefinition)
+				{
+					SootMethodAndClass method=((MethodSourceSinkDefinition) sourceSinkDef).getMethod();
+					String returnType=method.getReturnType();
+					boolean isMethodWithoutReturnType=	returnType==null||returnType.isEmpty();
+					if(isMethodWithoutReturnType)
+					{
+						String className=method.getClassName();
 						String subSignatureWithoutReturnType=(((MethodSourceSinkDefinition) sourceSinkDef).getMethod().getSubSignature());
-						SootMethod sootMethod=	grabMethod(className,subSignatureWithoutReturnType);
+						SootMethod sootMethod=	grabMethodWithoutReturn(className,subSignatureWithoutReturnType);
 						if(sootMethod!=null)
 							sinkMethods.put(sootMethod, sourceSinkDef);
 					}
+					else{
+						SootMethod sm = Scene.v().grabMethod(entry.getKey());
+						if (sm != null)
+							sinkMethods.put(sm, entry.getValue());
+					}
+
 				} else if (sourceSinkDef instanceof FieldSourceSinkDefinition) {
 					SootField sf = Scene.v().grabField(entry.getKey());
 					if (sf != null)
@@ -1063,7 +1092,7 @@ public class AndroidSourceSinkManager implements ISourceSinkManager, IOneSourceA
 	/**
 	 * Excludes the given method from the source/sink analysis. No sources or sinks
 	 * will be detected in excluded methods.
-	 * 
+	 *
 	 * @param toExclude
 	 *            The method to exclude
 	 */

--- a/soot-infoflow/src/soot/jimple/infoflow/results/xml/InfoflowResultsSerializer.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/results/xml/InfoflowResultsSerializer.java
@@ -24,7 +24,7 @@ import soot.jimple.infoflow.solver.cfg.IInfoflowCFG;
  */
 public class InfoflowResultsSerializer {
 
-	public static final int FILE_FORMAT_VERSION = 100;
+	public static final int FILE_FORMAT_VERSION = 101;
 
 	protected boolean serializeTaintPath = true;
 	protected IInfoflowCFG icfg;
@@ -122,6 +122,8 @@ public class InfoflowResultsSerializer {
 	private void writeSourceInfo(ResultSourceInfo source, XMLStreamWriter writer) throws XMLStreamException {
 		writer.writeStartElement(XmlConstants.Tags.source);
 		writer.writeAttribute(XmlConstants.Attributes.statement, source.getStmt().toString());
+		if(source.getDefinition().getCategory()!=null)
+			writer.writeAttribute(XmlConstants.Attributes.category,source.getDefinition().getCategory().getHumanReadableDescription());
 		if (icfg != null)
 			writer.writeAttribute(XmlConstants.Attributes.method, icfg.getMethodOf(source.getStmt()).getSignature());
 
@@ -135,6 +137,7 @@ public class InfoflowResultsSerializer {
 
 				Stmt curStmt = source.getPath()[i];
 				writer.writeAttribute(XmlConstants.Attributes.statement, curStmt.toString());
+
 				if (icfg != null)
 					writer.writeAttribute(XmlConstants.Attributes.method, icfg.getMethodOf(curStmt).getSignature());
 
@@ -178,6 +181,8 @@ public class InfoflowResultsSerializer {
 	private void writeSinkInfo(ResultSinkInfo sink, XMLStreamWriter writer) throws XMLStreamException {
 		writer.writeStartElement(XmlConstants.Tags.sink);
 		writer.writeAttribute(XmlConstants.Attributes.statement, sink.getStmt().toString());
+		if(sink.getDefinition().getCategory()!=null)
+			writer.writeAttribute(XmlConstants.Attributes.category,sink.getDefinition().getCategory().getHumanReadableDescription());
 		if (icfg != null)
 			writer.writeAttribute(XmlConstants.Attributes.method, icfg.getMethodOf(sink.getStmt()).getSignature());
 		writeAdditionalSinkInfo(sink, writer);

--- a/soot-infoflow/src/soot/jimple/infoflow/results/xml/XmlConstants.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/results/xml/XmlConstants.java
@@ -40,8 +40,8 @@ class XmlConstants {
 		public static final String value = "Value";
 		public static final String type = "Type";
 		public static final String taintSubFields = "TaintSubFields";
-		
-		
+
+		public static final String category = "Category";
 	}
 	
 	class Values {

--- a/soot-infoflow/src/soot/jimple/infoflow/rifl/RIFLParser.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/rifl/RIFLParser.java
@@ -66,154 +66,144 @@ public class RIFLParser {
 		try {
 			SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
 			parser.parse(riflFile, new DefaultHandler() {
-				
+
+
 				private Stack<RIFLState> stateStack = new Stack<>();
-				
+
 				private String assignableHandle = "";
 				private Assignable assignable = null;
 				private SourceSinkSpec sourceSinkSpec = null;
-				
+
+
 				@Override
 				public void startDocument() throws SAXException {
 					super.startDocument();
 					stateStack.push(RIFLState.RiflSpec);
 				}
-				
+
 				@Override
 				public void startElement(String uri, String localName,
-						String qName, Attributes attributes)
+										 String qName, Attributes attributes)
 						throws SAXException {
 					super.startElement(uri, localName, qName, attributes);
-					
+
 					RIFLState curState = stateStack.peek();
 					if (curState == RIFLState.RiflSpec
-							&& localName.equalsIgnoreCase(RIFLConstants.INTERFACE_SPEC_TAG)) {
+							&& (qName.equalsIgnoreCase(RIFLConstants.INTERFACE_SPEC_TAG) || localName.equalsIgnoreCase(RIFLConstants.INTERFACE_SPEC_TAG))) {
 						stateStack.push(RIFLState.InterfaceSpec);
-					}
-					else if (curState == RIFLState.InterfaceSpec
-							&& localName.equalsIgnoreCase(RIFLConstants.ASSIGNABLE_TAG)) {
+					} else if (curState == RIFLState.InterfaceSpec
+							&& (qName.equalsIgnoreCase(RIFLConstants.ASSIGNABLE_TAG) || localName.equalsIgnoreCase(RIFLConstants.ASSIGNABLE_TAG))) {
 						stateStack.push(RIFLState.Assignable);
 						assignableHandle = attributes.getValue(RIFLConstants.HANDLE_ATTRIBUTE);
 					}
-					else if (curState == RIFLState.Assignable
-							&& localName.equalsIgnoreCase(RIFLConstants.SOURCE_TAG)) {
-						stateStack.push(RIFLState.Source);
-					}
 					else if ((curState == RIFLState.Source || curState == RIFLState.Sink)
-							&& localName.equalsIgnoreCase(RIFLConstants.PARAMETER_TAG)) {
+							&& (qName.equalsIgnoreCase(RIFLConstants.PARAMETER_TAG) || localName.equalsIgnoreCase(RIFLConstants.PARAMETER_TAG))) {
 						stateStack.push(RIFLState.Parameter);
-						
+
 						int parameterIdx = Integer.parseInt(attributes.getValue(RIFLConstants.PARAMETER_ATTRIBUTE));
 						String className = attributes.getValue(RIFLConstants.CLASS_ATTRIBUTE);
 						String methodSig = attributes.getValue(RIFLConstants.METHOD_ATTRIBUTE);
-						
+
 						SourceSinkType type = getSourceSinkTypeFromState(curState);
 						SourceSinkSpec newSpec = doc.new JavaParameterSpec(type, className,
 								methodSig, parameterIdx);
-						
+
 						if (sourceSinkSpec == null)
 							sourceSinkSpec = newSpec;
 						else if (sourceSinkSpec instanceof Category)
 							((Category) sourceSinkSpec).getElements().add(newSpec);
 					}
+
 					else if ((curState == RIFLState.Source || curState == RIFLState.Sink)
-							&& localName.equalsIgnoreCase(RIFLConstants.FIELD_TAG)) {
+							&& (qName.equalsIgnoreCase(RIFLConstants.RETURN_VALUE_TAG) || localName.equalsIgnoreCase(RIFLConstants.RETURN_VALUE_TAG))) {
 						stateStack.push(RIFLState.Field);
-						
-						String className = attributes.getValue(RIFLConstants.CLASS_ATTRIBUTE);
-						String fieldSig = attributes.getValue(RIFLConstants.FIELD_ATTRIBUTE);
-						
-						SourceSinkType type = getSourceSinkTypeFromState(curState);
-						SourceSinkSpec newSpec = doc.new JavaFieldSpec(type, className, fieldSig);
-						
-						if (sourceSinkSpec == null)
-							sourceSinkSpec = newSpec;
-						else if (sourceSinkSpec instanceof Category)
-							((Category) sourceSinkSpec).getElements().add(newSpec);
-					}
-					else if ((curState == RIFLState.Source || curState == RIFLState.Sink)
-							&& localName.equalsIgnoreCase(RIFLConstants.RETURN_VALUE_TAG)) {
-						stateStack.push(RIFLState.Field);
-						
+
 						String className = attributes.getValue(RIFLConstants.CLASS_ATTRIBUTE);
 						String methodSig = attributes.getValue(RIFLConstants.METHOD_ATTRIBUTE);
-						
+
 						SourceSinkType type = getSourceSinkTypeFromState(curState);
 						SourceSinkSpec newSpec = doc.new JavaReturnValueSpec(type, className, methodSig);
-						
+
 						if (sourceSinkSpec == null)
 							sourceSinkSpec = newSpec;
 						else if (sourceSinkSpec instanceof Category)
 							((Category) sourceSinkSpec).getElements().add(newSpec);
-					}
-					else if (curState == RIFLState.Assignable
-							&& localName.equalsIgnoreCase(RIFLConstants.CATEGORY_TAG)) {
+					} else if (curState == RIFLState.Assignable
+							&& (qName.equalsIgnoreCase(RIFLConstants.CATEGORY_TAG) || localName.equalsIgnoreCase(RIFLConstants.CATEGORY_TAG))) {
+						stateStack.push(RIFLState.Category);
+
+
+					} else if (curState == RIFLState.Category
+							&& (qName.equalsIgnoreCase(RIFLConstants.CATEGORY_TAG) || localName.equalsIgnoreCase(RIFLConstants.CATEGORY_TAG))) {
 						stateStack.push(RIFLState.Category);
 						sourceSinkSpec = doc.new Category(attributes.getValue(RIFLConstants.NAME_ATTRIBUTE));
-					}
-					else if (curState == RIFLState.RiflSpec
-							&& localName.equalsIgnoreCase(RIFLConstants.DOMAINS_TAG)) {
+					} else if (curState == RIFLState.Category
+							&& (qName.equalsIgnoreCase(RIFLConstants.SOURCE_TAG) || localName.equalsIgnoreCase(RIFLConstants.SOURCE_TAG))) {
+						stateStack.push(RIFLState.Source);
+					} else if (curState == RIFLState.Category
+							&& (qName.equalsIgnoreCase(RIFLConstants.SINK_TAG) || localName.equalsIgnoreCase(RIFLConstants.SINK_TAG))) {
+						stateStack.push(RIFLState.Sink);
+					} else if (curState == RIFLState.RiflSpec
+							&& (qName.equalsIgnoreCase(RIFLConstants.DOMAINS_TAG) || localName.equalsIgnoreCase(RIFLConstants.DOMAINS_TAG))) {
 						stateStack.push(RIFLState.Domains);
-					}
-					else if (curState == RIFLState.Domains
-							&& localName.equalsIgnoreCase(RIFLConstants.DOMAIN_TAG)) {
+					} else if (curState == RIFLState.Domains
+							&& (qName.equalsIgnoreCase(RIFLConstants.DOMAIN_TAG) || localName.equalsIgnoreCase(RIFLConstants.DOMAIN_TAG))) {
 						stateStack.push(RIFLState.Domain);
 						doc.getDomains().add(doc.new DomainSpec(attributes.getValue(RIFLConstants.NAME_ATTRIBUTE)));
-					}
-					else if (curState == RIFLState.RiflSpec
-							&& localName.equalsIgnoreCase(RIFLConstants.FLOW_RELATION_TAG)) {
+					} else if (curState == RIFLState.RiflSpec
+							&& (qName.equalsIgnoreCase(RIFLConstants.FLOW_RELATION_TAG) || localName.equalsIgnoreCase(RIFLConstants.FLOW_RELATION_TAG))) {
 						stateStack.push(RIFLState.FlowRelation);
-					}
-					else if (curState == RIFLState.FlowRelation
-							&& localName.equalsIgnoreCase(RIFLConstants.FLOW_TAG)) {
+					} else if (curState == RIFLState.FlowRelation
+							&& (qName.equalsIgnoreCase(RIFLConstants.FLOW_TAG) || localName.equalsIgnoreCase(RIFLConstants.FLOW_TAG))) {
 						stateStack.push(RIFLState.Flow);
-						
+
 						String fromDomain = attributes.getValue(RIFLConstants.FROM_ATTRIBUTE);
 						String toDomain = attributes.getValue(RIFLConstants.TO_ATTRIBUTE);
-						
+
 						doc.getFlowPolicy().add(doc.new FlowPair(doc.getDomainByName(fromDomain),
 								doc.getDomainByName(toDomain)));
-					}
-					else if (curState == RIFLState.RiflSpec
-							&& localName.equalsIgnoreCase(RIFLConstants.DOMAIN_ASSIGNMENT_TAG)) {
+					} else if (curState == RIFLState.RiflSpec
+							&& (qName.equalsIgnoreCase(RIFLConstants.DOMAIN_ASSIGNMENT_TAG) || localName.equalsIgnoreCase(RIFLConstants.DOMAIN_ASSIGNMENT_TAG))) {
 						stateStack.push(RIFLState.DomainAssignments);
-					}
-					else if (curState == RIFLState.DomainAssignments
-							&& localName.equalsIgnoreCase(RIFLConstants.ASSIGN_TAG)) {
+					} else if (curState == RIFLState.DomainAssignments
+							&& (qName.equalsIgnoreCase(RIFLConstants.ASSIGN_TAG) || localName.equalsIgnoreCase(RIFLConstants.ASSIGN_TAG))) {
 						stateStack.push(RIFLState.Assign);
-						
+
 						String assignableName = attributes.getValue(RIFLConstants.HANDLE_ATTRIBUTE);
 						String domainName = attributes.getValue(RIFLConstants.DOMAIN_ATTRIBUTE);
-						
+
 						doc.getDomainAssignment().add(doc.new DomainAssignment(
 								doc.getInterfaceSpec().getElementByHandle(assignableName),
 								doc.getDomainByName(domainName)));
 					}
+
 				}
-				
+
 				private SourceSinkType getSourceSinkTypeFromState(
 						RIFLState curState) {
 					switch (curState) {
-					case Source:
-						return SourceSinkType.Source;
-					case Sink:
-						return SourceSinkType.Sink;
-					default:
-						throw new RuntimeException("Invalid source/sink type: " + curState);
+						case Source:
+							return SourceSinkType.Source;
+						case Sink:
+							return SourceSinkType.Sink;
+						default:
+							throw new RuntimeException("Invalid source/sink type: " + curState);
 					}
 				}
 
 				@Override
 				public void endElement(String uri, String localName,
-						String qName) throws SAXException {
+									   String qName) throws SAXException {
 					super.endElement(uri, localName, qName);
-					
+
 					RIFLState curState = stateStack.pop();
+
 					if (curState == RIFLState.Assignable) {
 						assignable = doc.new Assignable(assignableHandle, sourceSinkSpec);
 						doc.getInterfaceSpec().getSourcesSinks().add(assignable);
 						sourceSinkSpec = null;
 					}
+
 				}
 				
 			});

--- a/soot-infoflow/src/soot/jimple/infoflow/util/SootMethodRepresentationParser.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/util/SootMethodRepresentationParser.java
@@ -138,6 +138,7 @@ public class SootMethodRepresentationParser {
 
 	/**
 	 * Parses a Soot method subsignature and returns the method name
+	 *
 	 * @param subSignature The Soot subsignature to parse
 	 * @return The name of the method being invoked if the given subsignature
 	 * could be parsed successfully, otherwise an empty string.
@@ -148,13 +149,19 @@ public class SootMethodRepresentationParser {
 			this.patternSubsigToName = pattern;
 		}
 		Matcher matcher = patternSubsigToName.matcher(subSignature);
-		if (matcher.find())
-			return matcher.group(2);
-		return "";
+
+		if (!matcher.find() ) {    //in case no return value exists
+			Pattern pattern = Pattern.compile("^\\s*(.+)\\((.*?)\\)\\s*$");
+			this.patternSubsigToName = pattern;
+			return getMethodNameFromSubSignature(subSignature);
+		}
+		String method = matcher.group(matcher.groupCount()-1);
+		return method;
 	}
 
 	/**
 	 * Parses a Soot method subsignature and returns the list of parameter types
+	 *
 	 * @param subSignature The Soot subsignature to parse
 	 * @return The list of formal parameters in the given subsignature invoked
 	 * if the given subsignature could be parsed successfully, otherwise null.
@@ -165,11 +172,17 @@ public class SootMethodRepresentationParser {
 			this.patternSubsigToName = pattern;
 		}
 		Matcher matcher = patternSubsigToName.matcher(subSignature);
-		if (!matcher.find() || matcher.groupCount() < 3)
+		if (!matcher.find() ) {    //in case no return value exists
+			Pattern pattern = Pattern.compile("^\\s*(.+)\\((.*?)\\)\\s*$");
+			this.patternSubsigToName = pattern;
+			return getParameterTypesFromSubSignature(subSignature);
+		}
+		String params = matcher.group(matcher.groupCount());
+		if(params.equals(""))
 			return null;
-		
-		String params = matcher.group(3);
-		return params.split("\\s*,\\s*");
+		else
+			return params.split("\\s*,\\s*");
+
 	}
 
 }


### PR DESCRIPTION
Fix parsing RIFL file by:

1-Handle input XML elements.
2-Handle no return type in the method signature.

And serialize category of source and sinks data leaks into the XML output file