### PR TITLE
ArrayResource: getter getArrayElements() created

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
@@ -16,6 +16,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -861,6 +862,10 @@ public class ARSCFileParser extends AbstractResourceParser {
 		@Override
 		public String toString() {
 			return this.arrayElements.toString();
+		}
+
+		public List<AbstractResource> getArrayElements() {
+			return Collections.unmodifiableList(arrayElements);
 		}
 
 		@Override


### PR DESCRIPTION
The new ArrayResource was missing a getter for the list elements