### PR TITLE
Hot fix, returning the right category from getHumanReadableDescription and getID in RIFL way

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/rifl/RIFLSourceSinkDefinitionProvider.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/rifl/RIFLSourceSinkDefinitionProvider.java
@@ -65,30 +65,32 @@ public class RIFLSourceSinkDefinitionProvider implements ISourceSinkDefinitionPr
 	private void parseRawDefinition(SourceSinkSpec element) {
 		if (element.getType() == SourceSinkType.Source) {
 			SourceSinkDefinition sourceSinkDefinition = parseDefinition(element, SourceSinkType.Source);
+			final String permanentCategory=lastCategory;
 			sourceSinkDefinition.setCategory(new ISourceSinkCategory() {
 				@Override
 				public String getHumanReadableDescription() {
-					return lastCategory;
+					return permanentCategory;
 				}
 
 				@Override
 				public String getID() {
-					return lastCategory;
+					return permanentCategory;
 				}
 			});
 			sources.add(sourceSinkDefinition);
 
 		} else if (element.getType() == SourceSinkType.Sink) {
 			SourceSinkDefinition sourceSinkDefinition = parseDefinition(element, SourceSinkType.Sink);
+            final String permanentCategory=lastCategory;
 			sourceSinkDefinition.setCategory(new ISourceSinkCategory() {
 				@Override
 				public String getHumanReadableDescription() {
-					return lastCategory;
+					return permanentCategory;
 				}
 
 				@Override
 				public String getID() {
-					return lastCategory.toUpperCase(Locale.US);
+					return permanentCategory.toUpperCase(Locale.US);
 				}
 			});
 			sinks.add(sourceSinkDefinition);


### PR DESCRIPTION
Before this commit, the last parsed category from RIFL file only returning when calling `getHumanReadableDescription` that used to serialize the category to the output file or `getID`.
Now, returning the right parsed categories.