### PR TITLE
Remove HEROS sovler from prompt

### DIFF
--- a/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
+++ b/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
@@ -178,7 +178,7 @@ public class MainClass {
 		options.addOption(OPTION_CALLBACK_ANALYZER, "callbackanalyzer", true,
 				"Use the specified callback analyzer (DEFAULT, FAST)");
 		options.addOption(OPTION_DATA_FLOW_SOLVER, "dataflowsolver", true,
-				"Use the specified data flow solver (HEROS, CONTEXTFLOWSENSITIVE, FLOWINSENSITIVE)");
+				"Use the specified data flow solver (CONTEXTFLOWSENSITIVE, FLOWINSENSITIVE)");
 		options.addOption(OPTION_ALIAS_ALGO, "aliasalgo", true,
 				"Use the specified aliasing algorithm (NONE, FLOWSENSITIVE, PTSBASED, LAZY)");
 		options.addOption(OPTION_CODE_ELIMINATION_MODE, "codeelimination", true,


### PR DESCRIPTION
Is "HEROS" still supported?

From what I understand, it's either FLOWINSENSITIVE or CONTEXTFLOWSENSITIVE, right? [Link to parser](https://github.com/secure-software-engineering/FlowDroid/blob/develop/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java#L417)

If that's the case, I created this PR to remove this line from cmd prompt. If I'm wrong about it, feel free to close it.