### PR TITLE
Fix missing removal of callgraph edges for removed callsites in deadcode elimination

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/DeadCodeEliminator.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/DeadCodeEliminator.java
@@ -106,7 +106,7 @@ public class DeadCodeEliminator implements ICodeOptimizer {
 	 * @param oldCallSites A list of callsites that where previously contained by the method's body and have to be
 	 *                     checked if still existent
 	 */
-	public static void removeDeadCallgraphEdges(SootMethod method, List<Unit> oldCallSites) {
+	static void removeDeadCallgraphEdges(SootMethod method, List<Unit> oldCallSites) {
 		List<Unit> newCallSites = getCallsInMethod(method);
 		if (oldCallSites != null)
 			for (Unit u : oldCallSites)
@@ -121,7 +121,7 @@ public class DeadCodeEliminator implements ICodeOptimizer {
 	 * @return The list of units calling other methods in the given method if there
 	 *         is at least one such unit. Otherwise null.
 	 */
-	public static List<Unit> getCallsInMethod(SootMethod method) {
+	static List<Unit> getCallsInMethod(SootMethod method) {
 		List<Unit> callSites = null;
 		for (Unit u : method.getActiveBody().getUnits())
 			if (((Stmt) u).containsInvokeExpr()) {

--- a/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/DeadCodeEliminator.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/DeadCodeEliminator.java
@@ -45,24 +45,22 @@ public class DeadCodeEliminator implements ICodeOptimizer {
 		// inter-procedural one
 		for (QueueReader<MethodOrMethodContext> rdr = Scene.v().getReachableMethods().listener(); rdr.hasNext();) {
 			MethodOrMethodContext sm = rdr.next();
-			if (sm.method() == null || !sm.method().hasActiveBody())
+			SootMethod method = sm.method();
+
+			if (method == null || !method.hasActiveBody())
 				continue;
 
 			// Exclude the dummy main method
-			if (entryPoints.contains(sm.method()))
+			if (entryPoints.contains(method))
 				continue;
 
-			List<Unit> callSites = getCallsInMethod(sm.method());
+			List<Unit> callSites = getCallsInMethod(method);
 
-			ConstantPropagatorAndFolder.v().transform(sm.method().getActiveBody());
-			DeadAssignmentEliminator.v().transform(sm.method().getActiveBody());
+			ConstantPropagatorAndFolder.v().transform(method.getActiveBody());
+			DeadAssignmentEliminator.v().transform(method.getActiveBody());
 
 			// Remove the dead callgraph edges
-			List<Unit> newCallSites = getCallsInMethod(sm.method());
-			if (callSites != null)
-				for (Unit u : callSites)
-					if (newCallSites == null || !newCallSites.contains(u))
-						Scene.v().getCallGraph().removeAllEdgesOutOf(u);
+			removeDeadCallgraphEdges(method, callSites);
 		}
 
 		// Perform an inter-procedural constant propagation and code cleanup
@@ -78,24 +76,42 @@ public class DeadCodeEliminator implements ICodeOptimizer {
 		for (QueueReader<MethodOrMethodContext> rdr = Scene.v().getReachableMethods().listener(); rdr.hasNext();) {
 			MethodOrMethodContext sm = rdr.next();
 
-			if (sm.method() == null || !sm.method().hasActiveBody())
+			SootMethod method = sm.method();
+
+			if (method == null || !method.hasActiveBody())
 				continue;
 			if (config.getIgnoreFlowsInSystemPackages()
+<<<<<<< HEAD
 					&& SystemClassHandler.v().isClassInSystemPackage(sm.method().getDeclaringClass().getName()))
+=======
+					&& SystemClassHandler.isClassInSystemPackage(method.getDeclaringClass().getName()))
+>>>>>>> 7aa953e... Fix DeadCodeElimination to remove all callgraph edges for which the callsites where removed during elimination.
 				continue;
 
-			ConditionalBranchFolder.v().transform(sm.method().getActiveBody());
+			ConditionalBranchFolder.v().transform(method.getActiveBody());
 
 			// Delete all dead code. We need to be careful and patch the cfg so
 			// that it does not retain edges for call statements we have deleted
-			List<Unit> callSites = getCallsInMethod(sm.method());
-			UnreachableCodeEliminator.v().transform(sm.method().getActiveBody());
-			List<Unit> newCallSites = getCallsInMethod(sm.method());
-			if (callSites != null)
-				for (Unit u : callSites)
-					if (newCallSites == null || !newCallSites.contains(u))
-						Scene.v().getCallGraph().removeAllEdgesOutOf(u);
+			List<Unit> callSites = getCallsInMethod(method);
+			UnreachableCodeEliminator.v().transform(method.getActiveBody());
+			removeDeadCallgraphEdges(method, callSites);
 		}
+	}
+
+	/**
+	 * Collects all callsites of the given method and removes all edges from the callgraph that correspond to callsites
+	 * which are not in the given set of previously contained callsites.
+	 *
+	 * @param method The method which's outgoing callgraph edges should be sanitized
+	 * @param oldCallSites A list of callsites that where previously contained by the method's body and have to be
+	 *                     checked if still existent
+	 */
+	public static void removeDeadCallgraphEdges(SootMethod method, List<Unit> oldCallSites) {
+		List<Unit> newCallSites = getCallsInMethod(method);
+		if (oldCallSites != null)
+			for (Unit u : oldCallSites)
+				if (newCallSites == null || !newCallSites.contains(u))
+					Scene.v().getCallGraph().removeAllEdgesOutOf(u);
 	}
 
 	/**
@@ -105,7 +121,7 @@ public class DeadCodeEliminator implements ICodeOptimizer {
 	 * @return The list of units calling other methods in the given method if there
 	 *         is at least one such unit. Otherwise null.
 	 */
-	private List<Unit> getCallsInMethod(SootMethod method) {
+	public static List<Unit> getCallsInMethod(SootMethod method) {
 		List<Unit> callSites = null;
 		for (Unit u : method.getActiveBody().getUnits())
 			if (((Stmt) u).containsInvokeExpr()) {

--- a/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/DeadCodeEliminator.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/DeadCodeEliminator.java
@@ -81,11 +81,7 @@ public class DeadCodeEliminator implements ICodeOptimizer {
 			if (method == null || !method.hasActiveBody())
 				continue;
 			if (config.getIgnoreFlowsInSystemPackages()
-<<<<<<< HEAD
 					&& SystemClassHandler.v().isClassInSystemPackage(sm.method().getDeclaringClass().getName()))
-=======
-					&& SystemClassHandler.isClassInSystemPackage(method.getDeclaringClass().getName()))
->>>>>>> 7aa953e... Fix DeadCodeElimination to remove all callgraph edges for which the callsites where removed during elimination.
 				continue;
 
 			ConditionalBranchFolder.v().transform(method.getActiveBody());

--- a/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/InterproceduralConstantValuePropagator.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/codeOptimization/InterproceduralConstantValuePropagator.java
@@ -208,12 +208,18 @@ public class InterproceduralConstantValuePropagator extends SceneTransformer {
 			MethodOrMethodContext mom = rdr.next();
 			SootMethod sm = mom.method();
 			if (sm.hasActiveBody()) {
+				List<Unit> oldCallSites = DeadCodeEliminator.getCallsInMethod(sm);
+
 				Body body = sm.retrieveActiveBody();
 				ConditionalBranchFolder.v().transform(body);
 				UnconditionalBranchFolder.v().transform(body);
 				DeadAssignmentEliminator.v().transform(body);
 				UnreachableCodeEliminator.v().transform(body);
 				UnusedLocalEliminator.v().transform(body);
+
+				// We need to be careful and patch the cfg so
+				// that it does not retain edges for call statements we have deleted
+				DeadCodeEliminator.removeDeadCallgraphEdges(sm, oldCallSites);
 			}
 		}
 


### PR DESCRIPTION
Without this fix, FlowDroid removes callsites from methods during deadcode elimination but does not remove the corresponding callgraph edges. This leads to errors in analyses that process callsites which are stored as sources of callgraph edges.