### PR TITLE
Fix: The life-cycle of false system classes was not built in their dummyMainMethod (related to #171)

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AbstractAndroidEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AbstractAndroidEntryPointCreator.java
@@ -10,12 +10,18 @@ import soot.SootMethod;
 import soot.jimple.Jimple;
 import soot.jimple.NopStmt;
 import soot.jimple.Stmt;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 import soot.jimple.infoflow.entryPointCreators.BaseEntryPointCreator;
-import soot.jimple.infoflow.util.SystemClassHandler;
 
 public abstract class AbstractAndroidEntryPointCreator extends BaseEntryPointCreator {
 
 	protected AndroidEntryPointUtils entryPointUtils = null;
+
+	protected ProcessManifest manifest;
+
+	public AbstractAndroidEntryPointCreator(ProcessManifest manifest) {
+		this.manifest = manifest;
+	}
 
 	@Override
 	public SootMethod createDummyMain() {
@@ -35,6 +41,7 @@ public abstract class AbstractAndroidEntryPointCreator extends BaseEntryPointCre
 			return null;
 
 		SootMethod method = findMethod(currentClass, subsignature);
+
 		if (method == null) {
 			logger.warn("Could not find Android entry point method: {}", subsignature);
 			return null;
@@ -47,7 +54,7 @@ public abstract class AbstractAndroidEntryPointCreator extends BaseEntryPointCre
 
 		// If this method is part of the Android framework, we don't need to
 		// call it
-		if (SystemClassHandler.v().isClassInSystemPackage(method.getDeclaringClass().getName()))
+		if (this.manifest.isExcluded(method.getDeclaringClass().getName()))
 			return null;
 
 		assert method.isStatic() || classLocal != null : "Class local was null for non-static method "

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AndroidEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AndroidEntryPointCreator.java
@@ -90,8 +90,6 @@ public class AndroidEntryPointCreator extends AbstractAndroidEntryPointCreator i
 
 	private Collection<SootClass> components;
 
-	private ProcessManifest manifest;
-
 	/**
 	 * Creates a new instance of the {@link AndroidEntryPointCreator} class and
 	 * registers a list of classes to be automatically scanned for Android lifecycle
@@ -101,7 +99,7 @@ public class AndroidEntryPointCreator extends AbstractAndroidEntryPointCreator i
 	 *                   lifecycle methods
 	 */
 	public AndroidEntryPointCreator(ProcessManifest manifest, Collection<SootClass> components) {
-		this.manifest = manifest;
+		super(manifest);
 		this.components = components;
 		this.overwriteDummyMainMethod = true;
 	}
@@ -215,7 +213,8 @@ public class AndroidEntryPointCreator extends AbstractAndroidEntryPointCreator i
 		for (SootClass parentActivity : fragmentClasses.keySet()) {
 			Set<SootClass> fragments = fragmentClasses.get(parentActivity);
 			for (SootClass fragment : fragments) {
-				FragmentEntryPointCreator entryPointCreator = new FragmentEntryPointCreator(fragment, applicationClass);
+				FragmentEntryPointCreator entryPointCreator = new FragmentEntryPointCreator(fragment, applicationClass,
+						this.manifest);
 				entryPointCreator.setDummyClassName(mainMethod.getDeclaringClass().getName());
 				entryPointCreator.setCallbacks(callbackFunctions.get(fragment));
 
@@ -250,21 +249,23 @@ public class AndroidEntryPointCreator extends AbstractAndroidEntryPointCreator i
 					}
 				}
 				componentCreator = new ActivityEntryPointCreator(currentClass, applicationClass,
-						activityLifecycleCallbacks, callbackClassToField, curActivityToFragmentMethod);
+						activityLifecycleCallbacks, callbackClassToField, curActivityToFragmentMethod, this.manifest);
 				break;
 			case Service:
 			case GCMBaseIntentService:
 			case GCMListenerService:
-				componentCreator = new ServiceEntryPointCreator(currentClass, applicationClass);
+				componentCreator = new ServiceEntryPointCreator(currentClass, applicationClass, this.manifest);
 				break;
 			case ServiceConnection:
-				componentCreator = new ServiceConnectionEntryPointCreator(currentClass, applicationClass);
+				componentCreator = new ServiceConnectionEntryPointCreator(currentClass, applicationClass,
+						this.manifest);
 				break;
 			case BroadcastReceiver:
-				componentCreator = new BroadcastReceiverEntryPointCreator(currentClass, applicationClass);
+				componentCreator = new BroadcastReceiverEntryPointCreator(currentClass, applicationClass,
+						this.manifest);
 				break;
 			case ContentProvider:
-				componentCreator = new ContentProviderEntryPointCreator(currentClass, applicationClass);
+				componentCreator = new ContentProviderEntryPointCreator(currentClass, applicationClass, this.manifest);
 				break;
 			default:
 				componentCreator = null;

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/AbstractComponentEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/AbstractComponentEntryPointCreator.java
@@ -21,6 +21,7 @@ import soot.jimple.NopStmt;
 import soot.jimple.NullConstant;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.entryPointCreators.AbstractAndroidEntryPointCreator;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 import soot.jimple.toolkits.scalar.NopEliminator;
 import soot.util.HashMultiMap;
 import soot.util.MultiMap;
@@ -42,7 +43,9 @@ public abstract class AbstractComponentEntryPointCreator extends AbstractAndroid
 	protected Local intentLocal = null;
 	protected SootField intentField = null;
 
-	public AbstractComponentEntryPointCreator(SootClass component, SootClass applicationClass) {
+	public AbstractComponentEntryPointCreator(SootClass component, SootClass applicationClass,
+			ProcessManifest manifest) {
+		super(manifest);
 		this.component = component;
 		this.applicationClass = applicationClass;
 		this.overwriteDummyMainMethod = true;

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ActivityEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ActivityEntryPointCreator.java
@@ -25,6 +25,7 @@ import soot.jimple.JimpleBody;
 import soot.jimple.NopStmt;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstants;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 import soot.jimple.infoflow.cfg.LibraryClassPatcher;
 import soot.jimple.infoflow.entryPointCreators.SimulatedCodeElementTag;
 import soot.util.MultiMap;
@@ -45,8 +46,8 @@ public class ActivityEntryPointCreator extends AbstractComponentEntryPointCreato
 
 	public ActivityEntryPointCreator(SootClass component, SootClass applicationClass,
 			MultiMap<SootClass, String> activityLifecycleCallbacks, Map<SootClass, SootField> callbackClassToField,
-			Map<SootClass, SootMethod> fragmentToMainMethod) {
-		super(component, applicationClass);
+			Map<SootClass, SootMethod> fragmentToMainMethod, ProcessManifest manifest) {
+		super(component, applicationClass, manifest);
 		this.activityLifecycleCallbacks = activityLifecycleCallbacks;
 		this.callbackClassToField = callbackClassToField;
 		this.fragmentToMainMethod = fragmentToMainMethod;

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/BroadcastReceiverEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/BroadcastReceiverEntryPointCreator.java
@@ -5,6 +5,7 @@ import soot.jimple.Jimple;
 import soot.jimple.NopStmt;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstants;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 
 /**
  * Entry point creator for Android broadcast receivers
@@ -14,8 +15,9 @@ import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstant
  */
 public class BroadcastReceiverEntryPointCreator extends AbstractComponentEntryPointCreator {
 
-	public BroadcastReceiverEntryPointCreator(SootClass component, SootClass applicationClass) {
-		super(component, applicationClass);
+	public BroadcastReceiverEntryPointCreator(SootClass component, SootClass applicationClass,
+			ProcessManifest manifest) {
+		super(component, applicationClass, manifest);
 	}
 
 	@Override

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ContentProviderEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ContentProviderEntryPointCreator.java
@@ -3,6 +3,7 @@ package soot.jimple.infoflow.android.entryPointCreators.components;
 import soot.SootClass;
 import soot.jimple.Jimple;
 import soot.jimple.NopStmt;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 
 /**
  * Entry point creator for content providers
@@ -12,8 +13,8 @@ import soot.jimple.NopStmt;
  */
 public class ContentProviderEntryPointCreator extends AbstractComponentEntryPointCreator {
 
-	public ContentProviderEntryPointCreator(SootClass component, SootClass applicationClass) {
-		super(component, applicationClass);
+	public ContentProviderEntryPointCreator(SootClass component, SootClass applicationClass, ProcessManifest manifest) {
+		super(component, applicationClass, manifest);
 	}
 
 	@Override

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/FragmentEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/FragmentEntryPointCreator.java
@@ -13,6 +13,7 @@ import soot.jimple.NopStmt;
 import soot.jimple.NullConstant;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstants;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 
 /**
  * Entry point creator for Android fragments
@@ -22,8 +23,8 @@ import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstant
  */
 public class FragmentEntryPointCreator extends AbstractComponentEntryPointCreator {
 
-	public FragmentEntryPointCreator(SootClass component, SootClass applicationClass) {
-		super(component, applicationClass);
+	public FragmentEntryPointCreator(SootClass component, SootClass applicationClass, ProcessManifest manifest) {
+		super(component, applicationClass, manifest);
 	}
 
 	@Override

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceConnectionEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceConnectionEntryPointCreator.java
@@ -4,6 +4,7 @@ import soot.SootClass;
 import soot.jimple.Jimple;
 import soot.jimple.NopStmt;
 import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstants;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 
 /**
  * Entry point creator for Android service connections
@@ -13,8 +14,9 @@ import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstant
  */
 public class ServiceConnectionEntryPointCreator extends AbstractComponentEntryPointCreator {
 
-	public ServiceConnectionEntryPointCreator(SootClass component, SootClass applicationClass) {
-		super(component, applicationClass);
+	public ServiceConnectionEntryPointCreator(SootClass component, SootClass applicationClass,
+			ProcessManifest manifest) {
+		super(component, applicationClass, manifest);
 	}
 
 	@Override

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceEntryPointCreator.java
@@ -16,6 +16,7 @@ import soot.jimple.NopStmt;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointConstants;
 import soot.jimple.infoflow.android.entryPointCreators.AndroidEntryPointUtils.ComponentType;
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
 import soot.jimple.infoflow.entryPointCreators.SimulatedCodeElementTag;
 
 /**
@@ -28,8 +29,8 @@ public class ServiceEntryPointCreator extends AbstractComponentEntryPointCreator
 
 	protected SootField binderField = null;
 
-	public ServiceEntryPointCreator(SootClass component, SootClass applicationClass) {
-		super(component, applicationClass);
+	public ServiceEntryPointCreator(SootClass component, SootClass applicationClass, ProcessManifest manifest) {
+		super(component, applicationClass, manifest);
 	}
 
 	@Override

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/manifest/ProcessManifest.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/manifest/ProcessManifest.java
@@ -39,7 +39,7 @@ public class ProcessManifest implements Closeable {
 	 * Enumeration containing the various component types supported in Android
 	 */
 	public enum ComponentType {
-	Activity, Service, ContentProvider, BroadcastReceiver
+		Activity, Service, ContentProvider, BroadcastReceiver
 	}
 
 	/**
@@ -289,7 +289,7 @@ public class ProcessManifest implements Closeable {
 	 * @return True if the given component shall be excluded from the analysis,
 	 *         false otherwise
 	 */
-	protected boolean isExcluded(String className) {
+	public boolean isExcluded(String className) {
 		return excludeSystemComponents && SystemClassHandler.v().isClassInSystemPackage(className);
 	}
 


### PR DESCRIPTION
The commit 2ec4cb2185f3707de9481eb2df8379b2097b7f66 did not solve the whole problem of #171. Indeed, while a false system component is now able to be represented in Flowdroid, its lifecycle cannot due to the same problem. This solution fixes the ad-hoc problem but I have seen 23 other similar checks in the code. I can impact other issues for false system classes.