### PR TITLE
Fix: generic way for testing if a class should be taken into account as a component

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/SetupApplication.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/SetupApplication.java
@@ -415,7 +415,7 @@ public class SetupApplication implements ITaintWrapperDataFlowAnalysis {
 		// To look for callbacks, we need to start somewhere. We use the Android
 		// lifecycle methods for this purpose.
 		this.manifest = new ProcessManifest(targetAPK);
-		this.manifest.setExcludeSystemComponents(config.getIgnoreFlowsInSystemPackages());
+		SystemClassHandler.v().setExcludeSystemComponents(config.getIgnoreFlowsInSystemPackages());
 		Set<String> entryPoints = manifest.getEntryPointClasses();
 		this.entrypoints = new HashSet<>(entryPoints.size());
 		for (String className : entryPoints) {

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AbstractAndroidEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AbstractAndroidEntryPointCreator.java
@@ -12,6 +12,7 @@ import soot.jimple.NopStmt;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.manifest.ProcessManifest;
 import soot.jimple.infoflow.entryPointCreators.BaseEntryPointCreator;
+import soot.jimple.infoflow.util.SystemClassHandler;
 
 public abstract class AbstractAndroidEntryPointCreator extends BaseEntryPointCreator {
 
@@ -54,7 +55,7 @@ public abstract class AbstractAndroidEntryPointCreator extends BaseEntryPointCre
 
 		// If this method is part of the Android framework, we don't need to
 		// call it
-		if (this.manifest.isExcluded(method.getDeclaringClass().getName()))
+		if (SystemClassHandler.v().isClassInSystemPackage(method.getDeclaringClass().getName()))
 			return null;
 
 		assert method.isStatic() || classLocal != null : "Class local was null for non-static method "

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/manifest/ProcessManifest.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/manifest/ProcessManifest.java
@@ -63,8 +63,6 @@ public class ProcessManifest implements Closeable {
 	protected List<AXmlNode> aliasActivities = null;
 	protected List<AXmlNode> receivers = null;
 
-	protected boolean excludeSystemComponents = true;
-
 	/**
 	 * Processes an AppManifest which is within the file identified by the given
 	 * path.
@@ -257,7 +255,7 @@ public class ProcessManifest implements Closeable {
 			AXmlAttribute<?> attr = node.getAttribute("name");
 			if (attr != null) {
 				String className = expandClassName((String) attr.getValue());
-				if (!isExcluded(className))
+				if (!SystemClassHandler.v().isClassInSystemPackage(className))
 					entryPoints.add(className);
 			} else {
 				// This component does not have a name, so this might be
@@ -271,7 +269,7 @@ public class ProcessManifest implements Closeable {
 							String name = (String) attrValue.getValue();
 							if (isValidComponentName(name)) {
 								String expandedName = expandClassName(name);
-								if (!isExcluded(expandedName))
+								if (!SystemClassHandler.v().isClassInSystemPackage(expandedName))
 									entryPoints.add(expandedName);
 							}
 						}
@@ -279,18 +277,6 @@ public class ProcessManifest implements Closeable {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Checks whether the given fully-qualified class name of an Android component
-	 * shall be excluded from the analysis
-	 * 
-	 * @param className The fully-qualified component class name to check
-	 * @return True if the given component shall be excluded from the analysis,
-	 *         false otherwise
-	 */
-	public boolean isExcluded(String className) {
-		return excludeSystemComponents && SystemClassHandler.v().isClassInSystemPackage(className);
 	}
 
 	/**
@@ -698,17 +684,6 @@ public class ProcessManifest implements Closeable {
 		}
 
 		return allLaunchableActivities;
-	}
-
-	/**
-	 * Sets whether components in system or framework-related packages shall be
-	 * excluded from the analysis
-	 * 
-	 * @param excludeSystemComponents True to exclude components in system packages
-	 *                                from the analysis, false otherwise
-	 */
-	public void setExcludeSystemComponents(boolean excludeSystemComponents) {
-		this.excludeSystemComponents = excludeSystemComponents;
 	}
 
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/util/SystemClassHandler.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/util/SystemClassHandler.java
@@ -15,6 +15,8 @@ public class SystemClassHandler {
 
 	private static SystemClassHandler instance;
 
+	private boolean excludeSystemComponents = true;
+
 	/**
 	 * Gets the global system class handler instance
 	 * 
@@ -43,10 +45,10 @@ public class SystemClassHandler {
 	 *         false
 	 */
 	public boolean isClassInSystemPackage(String className) {
-		return className.startsWith("android.") || className.startsWith("java.") || className.startsWith("javax.")
+		return (className.startsWith("android.") || className.startsWith("java.") || className.startsWith("javax.")
 				|| className.startsWith("sun.") || className.startsWith("org.omg.")
 				|| className.startsWith("org.w3c.dom.") || className.startsWith("com.google.")
-				|| className.startsWith("com.android.");
+				|| className.startsWith("com.android.")) && this.excludeSystemComponents;
 	}
 
 	/**
@@ -104,6 +106,17 @@ public class SystemClassHandler {
 		// We don't have a reason to believe that this taint is invisible to the
 		// callee
 		return true;
+	}
+
+	/**
+	 * Sets whether components in system or framework-related packages shall be
+	 * excluded from the analysis
+	 *
+	 * @param excludeSystemComponents True to exclude components in system packages
+	 *                                from the analysis, false otherwise
+	 */
+	public void setExcludeSystemComponents(boolean excludeSystemComponents) {
+		this.excludeSystemComponents = excludeSystemComponents;
 	}
 
 }


### PR DESCRIPTION
Actually, 2ec4cb2185f3707de9481eb2df8379b2097b7f66 and 89d4a3008592fb718a6a25c2ce1eba3b72d0dc6a did not fix the whole problem. Although it fixed #171, I found that the problem for #175 is the same, so I come with this more generic solution. It will avoid futur serial problems with the same issue as the test to know if a class is a system one is made more than 60 times in the entire code.
PS : In 89d4a3008592fb718a6a25c2ce1eba3b72d0dc6a I did move the manifest object in parent classes. It is not needed anymore for the moment but I did not remove it from the code as it may be useful in the futur. I don't know if you want to leave it or not, just let me know.