### PR TITLE
Add: com.google.android.maps.MapActivity entrypoint as Activity

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AndroidEntryPointConstants.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AndroidEntryPointConstants.java
@@ -32,6 +32,7 @@ public class AndroidEntryPointConstants {
 	public static final String FRAGMENTCLASS = "android.app.Fragment";
 	public static final String SUPPORTFRAGMENTCLASS = "android.support.v4.app.Fragment";
 	public static final String SERVICECONNECTIONINTERFACE = "android.content.ServiceConnection";
+	public static final String MAPACTIVITYCLASS = "com.google.android.maps.MapActivity";
 
 	public static final String APPCOMPATACTIVITYCLASS_V4 = "android.support.v4.app.AppCompatActivity";
 	public static final String APPCOMPATACTIVITYCLASS_V7 = "android.support.v7.app.AppCompatActivity";

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AndroidEntryPointUtils.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/AndroidEntryPointUtils.java
@@ -19,6 +19,7 @@ public class AndroidEntryPointUtils {
 
 	private SootClass osClassApplication;
 	private SootClass osClassActivity;
+	private SootClass osClassMapActivity;
 	private SootClass osClassService;
 	private SootClass osClassFragment;
 	private SootClass osClassSupportFragment;
@@ -53,6 +54,7 @@ public class AndroidEntryPointUtils {
 		osClassGCMListenerService = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.GCMLISTENERSERVICECLASS);
 		osInterfaceServiceConnection = Scene.v()
 				.getSootClassUnsafe(AndroidEntryPointConstants.SERVICECONNECTIONINTERFACE);
+		osClassMapActivity = Scene.v().getSootClassUnsafe(AndroidEntryPointConstants.MAPACTIVITYCLASS);
 	}
 
 	/**
@@ -108,6 +110,10 @@ public class AndroidEntryPointUtils {
 		else if (osInterfaceServiceConnection != null && Scene.v().getOrMakeFastHierarchy()
 				.canStoreType(currentClass.getType(), osInterfaceServiceConnection.getType()))
 			ctype = ComponentType.ServiceConnection;
+		// (10) com.google.android.maps.MapActivity
+		else if (osClassMapActivity != null && Scene.v().getOrMakeFastHierarchy().canStoreType(currentClass.getType(),
+				osClassMapActivity.getType()))
+			ctype = ComponentType.Activity;
 
 		componentTypeCache.put(currentClass, ctype);
 		return ctype;


### PR DESCRIPTION
Some apps use the com.google.android.maps.MapActivity (deprecated) super class to create activities. And even if they are declared in the AndroidManifest, in createDummyMainInternal method of AndroidEntryPointCreator class they would not be recognized as a component because the componentType would be "Plain" and not Activity. Therefore the component would not appear in the dummyMainMethod leading to a non-analyzed component. This PR fixes the problem.