### PR TITLE
Fixed callbacks in layout XML did not add to call graph bug

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/callbacks/AbstractCallbackAnalyzer.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/callbacks/AbstractCallbackAnalyzer.java
@@ -526,8 +526,12 @@ public abstract class AbstractCallbackAnalyzer {
 					|| curClass.getName().equals("android.support.v7.app.ActionBarActivity")
 					|| curClass.getName().equals("android.support.v7.app.AppCompatActivity"))
 				return true;
-			if (curClass.declaresMethod("void setContentView(int)"))
-				return false;
+            // As long as the class is subclass of android.app.Activity,
+            // it can be sure that the setContentView method is what we expected.
+            // Following 2 statements make the overriding of method
+            // setContentView ignored.
+			// if (curClass.declaresMethod("void setContentView(int)"))
+			// 	return false;
 			curClass = curClass.hasSuperclass() ? curClass.getSuperclass() : null;
 		}
 		return false;

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/config/SootConfigForAndroid.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/config/SootConfigForAndroid.java
@@ -25,7 +25,9 @@ public class SootConfigForAndroid implements IInfoflowConfig {
 		List<String> excludeList = new LinkedList<String>();
 		excludeList.add("java.*");
 		excludeList.add("sun.*");
-		excludeList.add("android.*");
+        // exclude classes of android.* will cause layout class cannot be 
+        // loaded for layout file based callback analysis.
+		// excludeList.add("android.*");
 		excludeList.add("org.apache.*");
 		excludeList.add("org.eclipse.*");
 		excludeList.add("soot.*");


### PR DESCRIPTION
For the case where customized activity extends from `androidx.appcompat.app.AppCompatActivity`, the invocation of the method `setContentView` is used to find the corresponding layout XML file and the method `invokesSetContentView` is used to judge the invocation of `setContentView`.  However, `invokesSetContentView` treated the situation that one of the superclass except than `android.app.Activity`, `android.support.v7.app.ActionBarActivity` and `android.support.v7.app.AppCompatActivity` with declaring of method `setContentView` as no invocation of `setContentView`. Since overriding method in the subclass is common such as it did in `androidx.appcompat.app.AppCompatActivity`, this is obviously incorrect and caused the skip of layout file analysis and lead to the missing of layout-resided callbacks in the call graph.

Also, for the case when activities extended from `android.support.v7.app.AppCompatActivity`. As the default configuration sets in `SootConfigForAndroid` that all classes start with **android** are excluded, during layout class loading in `LayoutFileParser`, relevant layout classes cannot be found thus leading to the skip of the layout file analysis.