### PR TITLE
Added commandline options (Partially related to issue #76)

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/SetupApplication.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/SetupApplication.java
@@ -1067,11 +1067,15 @@ public class SetupApplication implements ITaintWrapperDataFlowAnalysis {
 		else
 			Options.v().set_android_jars(androidJar);
 		Options.v().set_src_prec(Options.src_prec_apk_class_jimple);
-		Options.v().set_keep_line_number(false);
 		Options.v().set_keep_offset(false);
+		Options.v().set_keep_line_number(config.getEnableLineNumbers());
 		Options.v().set_throw_analysis(Options.throw_analysis_dalvik);
 		Options.v().set_process_multiple_dex(config.getMergeDexFiles());
 		Options.v().set_ignore_resolution_errors(true);
+
+		// Set soot phase option if original names should be used
+		if (config.getEnableOriginalNames())
+			Options.v().setPhaseOption("jb", "use-original-names:true");
 
 		// Set the Soot configuration options. Note that this will needs to be
 		// done before we compute the classpath.

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/config/XMLConfigurationParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/config/XMLConfigurationParser.java
@@ -210,6 +210,10 @@ public class XMLConfigurationParser {
 						config.setEnableArrayTracking(Boolean.valueOf(data));
 					else if (currentElement.equals(XMLConstants.TAG_ENABLE_REFLECTION))
 						config.setEnableReflection(Boolean.valueOf(data));
+					else if (currentElement.equals(XMLConstants.TAG_ENABLE_LINENUMBERS))
+						config.setEnableLineNumbers(Boolean.valueOf(data));
+					else if (currentElement.equals(XMLConstants.TAG_ENABLE_ORIGINALNAMES))
+						config.setEnableOriginalNames(Boolean.valueOf(data));
 					else if (currentElement.equals(XMLConstants.TAG_FLOW_SENSITIVE_ALIASING))
 						config.setFlowSensitiveAliasing(Boolean.valueOf(data));
 					else if (currentElement.equals(XMLConstants.TAG_LOG_SOURCES_AND_SINKS))

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/config/XMLConstants.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/config/XMLConstants.java
@@ -46,6 +46,8 @@ class XMLConstants {
 	public static final String TAG_ENABLE_EXCEPTIONS = "enableExceptions";
 	public static final String TAG_ENABLE_ARRAYS = "enableArrays";
 	public static final String TAG_ENABLE_REFLECTION = "enableReflection";
+	public static final String TAG_ENABLE_LINENUMBERS = "enableLineNumbers";
+	public static final String TAG_ENABLE_ORIGINALNAMES = "enableOriginalNames";
 	public static final String TAG_FLOW_SENSITIVE_ALIASING = "flowSensitiveAliasing";
 	public static final String TAG_LOG_SOURCES_AND_SINKS = "logSourcesAndSinks";
 	public static final String TAG_ENABLE_ARRAY_SIZE_TAINTING = "enableArraySizeTainting";

--- a/soot-infoflow-cmd/schema/FlowDroidConfiguration.xsd
+++ b/soot-infoflow-cmd/schema/FlowDroidConfiguration.xsd
@@ -151,6 +151,8 @@
 			<xs:element name="enableExceptions" type="xs:boolean" minOccurs="0" />
 			<xs:element name="enableArrays" type="xs:boolean" minOccurs="0" />
 			<xs:element name="enableReflection" type="xs:boolean" minOccurs="0" />
+			<xs:element name="enableLineNumbers" type="xs:boolean" minOccurs="0" />
+			<xs:element name="enableOriginalNames" type="xs:boolean" minOccurs="0" />
 			<xs:element name="flowSensitiveAliasing" type="xs:boolean" minOccurs="0" />
 			<xs:element name="logSourcesAndSinks" type="xs:boolean" minOccurs="0" />
 			<xs:element name="enableArraySizeTainting" type="xs:boolean" minOccurs="0" />

--- a/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
+++ b/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
@@ -80,6 +80,8 @@ public class MainClass {
 	private static final String OPTION_NO_TYPE_CHECKING = "nt";
 	private static final String OPTION_REFLECTION = "r";
 	private static final String OPTION_MISSING_SUMMARIES_FILE = "ms";
+	private static final String OPTION_OUTPUT_LINENUMBERS = "ol";
+	private static final String OPTION_ORIGINAL_NAMES = "on";
 
 	// Taint wrapper
 	private static final String OPTION_TAINT_WRAPPER = "tw";
@@ -158,6 +160,10 @@ public class MainClass {
 		options.addOption(OPTION_REFLECTION, "enablereflection", false, "Enable support for reflective method calls");
 		options.addOption(OPTION_MISSING_SUMMARIES_FILE, "missingsummariesoutputfile", true,
 				"Outputs a file with information about which summaries are missing");
+		options.addOption(OPTION_OUTPUT_LINENUMBERS, "outputlinenumbers", false,
+				"Enable the output of bytecode line numbers associated with sources and sinks in XML results");
+		options.addOption(OPTION_ORIGINAL_NAMES, "originalnames", false,
+				"Enable the usage of original variablenames if available");
 
 		// Taint wrapper
 		options.addOption(OPTION_TAINT_WRAPPER, "taintwrapper", true,
@@ -695,6 +701,10 @@ public class MainClass {
 			config.setEnableTypeChecking(false);
 		if (cmd.hasOption(OPTION_REFLECTION))
 			config.setEnableReflection(true);
+		if (cmd.hasOption(OPTION_OUTPUT_LINENUMBERS))
+			config.setEnableLineNumbers(true);
+		if (cmd.hasOption(OPTION_ORIGINAL_NAMES))
+			config.setEnableOriginalNames(true);
 		// Individual settings
 		{
 			Integer aplength = getIntOption(cmd, OPTION_ACCESS_PATH_LENGTH);

--- a/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
@@ -953,6 +953,8 @@ public class InfoflowConfiguration {
 	private boolean writeOutputFiles = false;
 	private boolean logSourcesAndSinks = false;
 	private boolean enableReflection = false;
+	private boolean enableLineNumbers = false;
+	private boolean enableOriginalNames = false;
 
 	private boolean inspectSources = false;
 	private boolean inspectSinks = false;
@@ -992,6 +994,8 @@ public class InfoflowConfiguration {
 		this.writeOutputFiles = config.writeOutputFiles;
 		this.logSourcesAndSinks = config.logSourcesAndSinks;
 		this.enableReflection = config.enableReflection;
+		this.enableLineNumbers = config.enableLineNumbers;
+		this.enableOriginalNames = config.enableOriginalNames;
 
 		this.pathConfiguration.merge(config.pathConfiguration);
 		this.outputConfiguration.merge(config.outputConfiguration);
@@ -1482,6 +1486,47 @@ public class InfoflowConfiguration {
 	}
 
 	/**
+	 * Gets whether line numbers associated with sources and sinks should be output
+	 * in XML results
+	 * 
+	 * @return True if line number should be output, otherwise false
+	 */
+	public boolean getEnableLineNumbers() {
+		return this.enableLineNumbers;
+	}
+
+	/**
+	 * Sets whether line numbers associated with sources and sinks should be output
+	 * in XML results
+	 * 
+	 * @param enableLineNumbers True if line numbers associated with sources and
+	 *                          sinks should be output in XML results, otherwise
+	 *                          false
+	 */
+	public void setEnableLineNumbers(boolean enableLineNumbers) {
+		this.enableLineNumbers = enableLineNumbers;
+	}
+
+	/**
+	 * Gets whether the usage of original variablenames (if available) is enabled
+	 * 
+	 * @return True if the usage is enabled, otherwise false
+	 */
+	public boolean getEnableOriginalNames() {
+		return this.enableOriginalNames;
+	}
+
+	/**
+	 * Sets whether the usage of original variablenames (if available) is enabled
+	 * 
+	 * @param enableOriginalNames True if the usage of original variablenames (if
+	 *                            available) is enabled, otherwise false
+	 */
+	public void setEnableOriginalNames(boolean enableOriginalNames) {
+		this.enableOriginalNames = enableOriginalNames;
+	}
+
+	/**
 	 * Gets whether the taint analysis is enabled. If it is disabled, FlowDroid will
 	 * initialize the Soot instance and then return immediately.
 	 * 
@@ -1680,6 +1725,8 @@ public class InfoflowConfiguration {
 		result = prime * result + (enableArrays ? 1231 : 1237);
 		result = prime * result + (enableExceptions ? 1231 : 1237);
 		result = prime * result + (enableReflection ? 1231 : 1237);
+		result = prime * result + (enableLineNumbers ? 1231 : 1237);
+		result = prime * result + (enableOriginalNames ? 1231 : 1237);
 		result = prime * result + (enableTypeChecking ? 1231 : 1237);
 		result = prime * result + (excludeSootLibraryClasses ? 1231 : 1237);
 		result = prime * result + (flowSensitiveAliasing ? 1231 : 1237);
@@ -1733,6 +1780,10 @@ public class InfoflowConfiguration {
 		if (enableExceptions != other.enableExceptions)
 			return false;
 		if (enableReflection != other.enableReflection)
+			return false;
+		if (enableLineNumbers != other.enableLineNumbers)
+			return false;
+		if (enableOriginalNames != other.enableOriginalNames)
 			return false;
 		if (enableTypeChecking != other.enableTypeChecking)
 			return false;

--- a/soot-infoflow/src/soot/jimple/infoflow/results/xml/InfoflowResultsSerializer.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/results/xml/InfoflowResultsSerializer.java
@@ -192,6 +192,9 @@ public class InfoflowResultsSerializer {
 	private void writeSourceInfo(ResultSourceInfo source, XMLStreamWriter writer) throws XMLStreamException {
 		writer.writeStartElement(XmlConstants.Tags.source);
 		writer.writeAttribute(XmlConstants.Attributes.statement, source.getStmt().toString());
+		if (config.getEnableLineNumbers())
+			writer.writeAttribute(XmlConstants.Attributes.linenumber,
+					String.valueOf(source.getStmt().getJavaSourceStartLineNumber()));
 		if (source.getDefinition().getCategory() != null)
 			writer.writeAttribute(XmlConstants.Attributes.category,
 					source.getDefinition().getCategory().getHumanReadableDescription());
@@ -246,6 +249,9 @@ public class InfoflowResultsSerializer {
 	private void writeSinkInfo(ResultSinkInfo sink, XMLStreamWriter writer) throws XMLStreamException {
 		writer.writeStartElement(XmlConstants.Tags.sink);
 		writer.writeAttribute(XmlConstants.Attributes.statement, sink.getStmt().toString());
+		if (config.getEnableLineNumbers())
+			writer.writeAttribute(XmlConstants.Attributes.linenumber,
+					String.valueOf(sink.getStmt().getJavaSourceStartLineNumber()));
 		if (sink.getDefinition().getCategory() != null)
 			writer.writeAttribute(XmlConstants.Attributes.category,
 					sink.getDefinition().getCategory().getHumanReadableDescription());

--- a/soot-infoflow/src/soot/jimple/infoflow/results/xml/XmlConstants.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/results/xml/XmlConstants.java
@@ -38,6 +38,7 @@ class XmlConstants {
 		public static final String fileFormatVersion = "FileFormatVersion";
 		public static final String terminationState = "TerminationState";
 		public static final String statement = "Statement";
+		public static final String linenumber = "LineNumber";
 		public static final String method = "Method";
 
 		public static final String value = "Value";


### PR DESCRIPTION
Added two commandline options and config options. One for outputting linenumbers in XML result files and another one to use original variable names if available. (Partially related to issue #76: https://github.com/secure-software-engineering/FlowDroid/issues/76)