### PR TITLE
Fix "local type not allowed in final code: null_type" exception

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/IccRedirectionCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/IccRedirectionCreator.java
@@ -339,7 +339,7 @@ public class IccRedirectionCreator {
 		paramTypes.add(RefType.v("android.os.IBinder"));
 		SootMethod method = serviceConnection.getMethod("onServiceConnected", paramTypes);
 
-		Local iLocal1 = lg.generateLocal(NullType.v());
+		Local iLocal1 = lg.generateLocal(RefType.v("android.content.ComponentName"));
 		b.getUnits().add(Jimple.v().newAssignStmt(iLocal1, NullConstant.v()));
 
 		List<Value> args = new ArrayList<Value>();


### PR DESCRIPTION
With IccTA enabled to detect ICC flows, when to instrument ```onServiceConnected(ComponentName, IBinder)``` for bound Service, a ```Local``` of ```NullType``` is created to represent the first argument of type ```ComponentName```. However, ```NullType``` is not acceptable in the final Jimple code generated by Soot, when validating the body. Thus, an exception with the following message will be thrown:

> (<dummyMainClass: void redirector0(android.content.ServiceConnection,android.content.Intent)>) local type not allowed in final code: null_type local

This simple fix replaces ```NullType``` with the correct type ```ComponentName```. Though even with this fix, FlowDroid still lacks the mechanism to detect ICC flows of bound Service, this fix can at least make sure FlowDroid finish its analysis without abnormal termination when ```onServiceConnected(ComponentName, IBinder)``` is used in the application code.

You can validate this fix by running test on DroidBench app *ServiceCommunication1*.