### PR TITLE
Fix exceptions thrown when handling ICC methods with no parameter

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/IccRedirectionCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/IccRedirectionCreator.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import soot.Body;
 import soot.Local;
 import soot.Modifier;
-import soot.NullType;
 import soot.PatchingChain;
 import soot.RefType;
 import soot.Scene;
@@ -430,6 +429,10 @@ public class IccRedirectionCreator {
 			args.add(arg1);
 			args.add(arg0);
 		} else {
+			// specially deal with ICC methods with no parameter, i.e., PendingIntent.send()
+			if (fromStmt.getInvokeExpr().getArgCount() == 0) {
+				return;
+			}
 			Value arg0 = fromStmt.getInvokeExpr().getArg(0);
 			args.add(arg0);
 		}


### PR DESCRIPTION
The current implementation of IccTA assumes ICC methods contain at least one parameter, which is an Intent. However, there are ICC methods without parameter. For example for methods in class `PendingIntent`, as the base object is already severed as an intent, a parameter of Intent is not necessary. IccTA cannot handle these methods and throws one of the following exceptions, depending on how Soot implements `getArg()` in different versions:

- For Soot version 4.0.0 included in FlowDroid's `pom.xml`, `NullPointerException` is thrown at the statement with `getArg()`.
- For the nightly-built version of Soot, `IllegalArgumentException` with message "value may not be null" is thrown at line 441 of `IccRedirectionCreator.java`.

Though when I checked ICC methods collected by IC3, I only found `PendingIntent.send()` with no parameter. Considering it may use in a large number of real-world apps, the exception should be fixed.

The patch provides a simple workaround to avoid the exception. Though I attempted to make IccTA work with `PendingIntent`, it is currently impossible: by the design of `PendingIntent`, there is no way to extract the Intent used to create a `PendingIntent`. A sophisticated data-flow analysis should be introduced to connect a `PendingIntent` and an Intent.

I created an example to reproduce the issue, which includes an ICC model (`iccmodel.txt`) generated by IC3.
[ICCNoArg.zip](https://github.com/secure-software-engineering/FlowDroid/files/4322877/ICCNoArg.zip)

Please use the following command to run FlowDroid:

```
-a /path/to/ICCNoArg.apk -p /path/to/android-platforms -s /path/to/sourcesandsinks -im /path/to/iccmodel.txt
```