### PR TITLE
Fix ICC for BroadcastReceivers and IntentServices

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/AbstractComponentEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/AbstractComponentEntryPointCreator.java
@@ -5,16 +5,23 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import soot.Body;
 import soot.Local;
+import soot.PatchingChain;
 import soot.RefType;
 import soot.Scene;
 import soot.SootClass;
 import soot.SootField;
 import soot.SootMethod;
 import soot.Type;
+import soot.Unit;
+import soot.Value;
+import soot.javaToJimple.LocalGenerator;
+import soot.jimple.IdentityStmt;
 import soot.jimple.Jimple;
 import soot.jimple.JimpleBody;
 import soot.jimple.NopStmt;
@@ -22,7 +29,9 @@ import soot.jimple.NullConstant;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.android.entryPointCreators.AbstractAndroidEntryPointCreator;
 import soot.jimple.infoflow.android.manifest.ProcessManifest;
+import soot.jimple.infoflow.entryPointCreators.SimulatedCodeElementTag;
 import soot.jimple.toolkits.scalar.NopEliminator;
+import soot.util.Chain;
 import soot.util.HashMultiMap;
 import soot.util.MultiMap;
 
@@ -42,6 +51,8 @@ public abstract class AbstractComponentEntryPointCreator extends AbstractAndroid
 	protected Local thisLocal = null;
 	protected Local intentLocal = null;
 	protected SootField intentField = null;
+
+	private static RefType INTENT_TYPE = RefType.v("android.content.Intent");
 
 	public AbstractComponentEntryPointCreator(SootClass component, SootClass applicationClass,
 			ProcessManifest manifest) {
@@ -190,7 +201,96 @@ public abstract class AbstractComponentEntryPointCreator extends AbstractAndroid
 				body.getUnits().add(Jimple.v().newReturnStmt(thisLocal));
 		}
 		NopEliminator.v().transform(body);
+
+		instrumentDummyMainMethod();
+
 		return mainMethod;
+	}
+
+	/**
+	 * Transfer Intent for such components that take an Intent as a parameter and do
+	 * not leverage getIntent() method for retrieving the received Intent.
+	 * 
+	 * Code adapted from FlowDroid v2.0.
+	 */
+	protected void instrumentDummyMainMethod() {
+		Body body = mainMethod.getActiveBody();
+
+		PatchingChain<Unit> units = body.getUnits();
+		for (Iterator<Unit> iter = units.snapshotIterator(); iter.hasNext();) {
+			Stmt stmt = (Stmt) iter.next();
+
+			if (stmt instanceof IdentityStmt) {
+				continue;
+			}
+
+			if (!stmt.containsInvokeExpr()) {
+				continue;
+			}
+
+			if (stmt.toString().contains("<init>")) {
+				continue;
+			}
+
+			List<Type> types = stmt.getInvokeExpr().getMethod().getParameterTypes();
+			for (int i = 0; i < types.size(); i++) {
+				Type type = types.get(i);
+
+				if (type.equals(INTENT_TYPE)) {
+					try {
+						assignIntent(component, stmt.getInvokeExpr().getMethod(), i + 1);
+					} catch (Exception ex) {
+						System.out.println("Assign Intent for " + stmt.getInvokeExpr().getMethod() + " fails.");
+					}
+
+				}
+			}
+		}
+	}
+
+	/**
+	 * Method used in instrumentDummyMainMethod() to transfer Intent
+	 * 
+	 * Code adapted from FlowDroid v2.0.
+	 */
+	public void assignIntent(SootClass hostComponent, SootMethod method, int indexOfArgs) {
+		Body body = method.getActiveBody();
+
+		PatchingChain<Unit> units = body.getUnits();
+		Chain<Local> locals = body.getLocals();
+		Value intentV = null;
+		int identityStmtIndex = 0;
+
+		for (Iterator<Unit> iter = units.snapshotIterator(); iter.hasNext();) {
+			Stmt stmt = (Stmt) iter.next();
+			if (!method.isStatic()) {
+				if (stmt instanceof IdentityStmt) {
+					if (identityStmtIndex == indexOfArgs) {
+						intentV = ((IdentityStmt) stmt).getLeftOp();
+					}
+
+					identityStmtIndex++;
+				} else {
+					Local thisLocal = locals.getFirst();
+
+					/*
+					 * Using the component that the dummyMain() belongs to, as in some cases the
+					 * invoked method is only available in its superclass. and its superclass does
+					 * not contain getIntent() and consequently cause an runtime exception of
+					 * couldn't find getIntent().
+					 * 
+					 * RuntimeException: couldn't find method getIntent(*) in
+					 * com.google.android.gcm.GCMBroadcastReceiver
+					 */
+					Unit setIntentU = Jimple.v().newAssignStmt(intentV, Jimple.v().newVirtualInvokeExpr(thisLocal,
+							hostComponent.getMethodByName("getIntent").makeRef()));
+
+					units.insertBefore(setIntentU, stmt);
+
+					return;
+				}
+			}
+		}
 	}
 
 	/**
@@ -369,4 +469,30 @@ public abstract class AbstractComponentEntryPointCreator extends AbstractAndroid
 		return info;
 	}
 
+	/**
+	 * Creates an implementation of getIntent() that returns the intent from our ICC
+	 * model
+	 */
+	protected void createGetIntentMethod() {
+		// We need to create an implementation of "getIntent". If there is already such
+		// an implementation, we don't touch it.
+		if (component.declaresMethod("android.content.Intent getIntent()"))
+			return;
+
+		Type intentType = RefType.v("android.content.Intent");
+		SootMethod sm = Scene.v().makeSootMethod("getIntent", Collections.<Type>emptyList(), intentType,
+				Modifier.PUBLIC);
+		component.addMethod(sm);
+		sm.addTag(SimulatedCodeElementTag.TAG);
+
+		JimpleBody b = Jimple.v().newBody(sm);
+		sm.setActiveBody(b);
+		b.insertIdentityStmts();
+
+		LocalGenerator localGen = new LocalGenerator(b);
+		Local lcIntent = localGen.generateLocal(intentType);
+		b.getUnits().add(Jimple.v().newAssignStmt(lcIntent,
+				Jimple.v().newInstanceFieldRef(b.getThisLocal(), intentField.makeRef())));
+		b.getUnits().add(Jimple.v().newReturnStmt(lcIntent));
+	}
 }

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ActivityEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ActivityEntryPointCreator.java
@@ -19,7 +19,6 @@ import soot.SootMethod;
 import soot.Type;
 import soot.Value;
 import soot.VoidType;
-import soot.javaToJimple.LocalGenerator;
 import soot.jimple.Jimple;
 import soot.jimple.JimpleBody;
 import soot.jimple.NopStmt;
@@ -232,33 +231,6 @@ public class ActivityEntryPointCreator extends AbstractComponentEntryPointCreato
 		createGetIntentMethod();
 		createSetIntentMethod();
 		createSetResultMethod();
-	}
-
-	/**
-	 * Creates an implementation of getIntent() that returns the intent from our ICC
-	 * model
-	 */
-	private void createGetIntentMethod() {
-		// We need to create an implementation of "getIntent". If there is already such
-		// an implementation, we don't touch it.
-		if (component.declaresMethod("android.content.Intent getIntent()"))
-			return;
-
-		Type intentType = RefType.v("android.content.Intent");
-		SootMethod sm = Scene.v().makeSootMethod("getIntent", Collections.<Type>emptyList(), intentType,
-				Modifier.PUBLIC);
-		component.addMethod(sm);
-		sm.addTag(SimulatedCodeElementTag.TAG);
-
-		JimpleBody b = Jimple.v().newBody(sm);
-		sm.setActiveBody(b);
-		b.insertIdentityStmts();
-
-		LocalGenerator localGen = new LocalGenerator(b);
-		Local lcIntent = localGen.generateLocal(intentType);
-		b.getUnits().add(Jimple.v().newAssignStmt(lcIntent,
-				Jimple.v().newInstanceFieldRef(b.getThisLocal(), intentField.makeRef())));
-		b.getUnits().add(Jimple.v().newReturnStmt(lcIntent));
 	}
 
 	/**

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/BroadcastReceiverEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/BroadcastReceiverEntryPointCreator.java
@@ -36,4 +36,11 @@ public class BroadcastReceiverEntryPointCreator extends AbstractComponentEntryPo
 		createIfStmt(onReceiveStmt);
 	}
 
+	@Override
+	protected void createAdditionalMethods() {
+		super.createAdditionalMethods();
+
+		createGetIntentMethod();
+	}
+
 }

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceEntryPointCreator.java
@@ -146,6 +146,8 @@ public class ServiceEntryPointCreator extends AbstractComponentEntryPointCreator
 
 		// We need to instrument the onBind() method to store the binder in the field
 		instrumentOnBind();
+
+		createGetIntentMethod();
 	}
 
 	/**


### PR DESCRIPTION
Different to FlowDroid v2.0, the logic of IccTA is changed, which leads to the current version fails to handle ICC targeted BroadcastReceivers and IntentServices. Specifically, it fails to handle `onReceive(Context, Intent)` of BroadcastReceivers  and `onHandleIntent(Intent)` of IntentServices in the following DroidBench or ICC-Bench benchmark apps:
- [BroadcastTaintAndLeak1](https://github.com/secure-software-engineering/DroidBench/tree/master/eclipse-project/InterComponentCommunication/BroadcastTaintAndLeak1)
- [icc_dynregister1](https://github.com/fgwei/ICC-Bench/tree/master/icc_dynregister1)
- [icc_dynregister2](https://github.com/fgwei/ICC-Bench/tree/master/icc_dynregister2)
- [icc_intentservice](https://github.com/fgwei/ICC-Bench/tree/master/icc_intentservice)

I thus adapted the source code from v2.0 to fill the gap. There is a method `instrumentDummyMainMethod()` in v2.0, which searches every reachable method from the dummy main of a component. If a method takes an Intent as a parameter, the tool further goes inside the method, and replaces the Intent parameter with `getIntent()` of the component.

I tested the patch on DroidBench v3.0 and ICC-Bench v2.0 and I did not notice any side effect. But please let me know if you have any suggestions or concerns on the patch.

Thank you.