### PR TITLE
readConfigTable fails in unit test because of assertion

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
@@ -2567,10 +2567,13 @@ public class ARSCFileParser extends AbstractResourceParser {
 		if (remainingSize > 0) {
 			byte[] remainingBytes = new byte[remainingSize];
 			System.arraycopy(data, offset, remainingBytes, 0, remainingSize);
-			if (!(new BigInteger(1, remainingBytes).equals(BigInteger.ZERO))) {
-				logger.warn("Excessive non-null bytes in ResTable_Config ignored");
-				assert false;
-			}
+			BigInteger remainingData = new BigInteger(1, remainingBytes);
+			if (!(remainingData.equals(BigInteger.ZERO))) {
+				logger.debug("Excessive {} non-null bytes in ResTable_Config ignored", remainingSize);
+				if (logger.isTraceEnabled()) {
+					logger.trace("remaining data: 0x" + remainingData.toString(16));
+				}
+            }
 			offset += remainingSize;
 		}
 


### PR DESCRIPTION
When loading the resources of an [android-platforms](https://github.com/Sable/android-platforms) android.jar the assertion on non-null extra bytes triggers in `readConfigTable`.
For example for API 26 I am getting extra bytes 0x100000000000000 and 0x200000000000000 multiple times.

In a regular program this is no problem as assertions are usually not enabled however in unit tests assertions are enabled by default and therefore all unit tests fail that need to load resources from an android-platform android.jar.