### PR TITLE
Stmt after onRestart should be a GotoStmt

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ActivityEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ActivityEntryPointCreator.java
@@ -199,8 +199,7 @@ public class ActivityEntryPointCreator extends AbstractComponentEntryPointCreato
 
 		// 6. onRestart:
 		searchAndBuildMethod(AndroidEntryPointConstants.ACTIVITY_ONRESTART, component, thisLocal);
-		createIfStmt(onStartStmt); // jump to onStart(), fall through to
-									// onDestroy()
+		body.getUnits().add(Jimple.v().newGotoStmt(onStartStmt)); // jump to onStart()
 
 		// 7. onDestroy
 		body.getUnits().add(stopToDestroyStmt);


### PR DESCRIPTION
The successor of lifecycle method onRestart()  is only onStart(). onDestroy() is not successor of onRestart(). 
Thus the stmt after onRestart() should be a GotoStmt instead of  IfStmt.

Reference : https://developer.android.google.cn/guide/components/activities/activity-lifecycle    
                
                  https://developer.android.google.cn/guide/components/images/activity_lifecycle.png