### PR TITLE
Fixed parseInt and parseLong method signatures in summaries

### DIFF
--- a/soot-infoflow-summaries/summariesManual/java.lang.Integer.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.Integer.xml
@@ -73,7 +73,7 @@
 				</flow>
 			</flows>
 		</method>
-		<method id="java.lang.Integer parseInt(java.lang.String)">
+		<method id="int parseInt(java.lang.String)">
 			<flows>
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
@@ -82,7 +82,7 @@
 				</flow>
 			</flows>
 		</method>
-		<method id="java.lang.Integer parseInt(java.lang.String,int)">
+		<method id="int parseInt(java.lang.String,int)">
 			<flows>
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />

--- a/soot-infoflow-summaries/summariesManual/java.lang.Long.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.Long.xml
@@ -73,7 +73,7 @@
 				</flow>
 			</flows>
 		</method>
-		<method id="java.lang.Long parseLong(java.lang.String)">
+		<method id="long parseLong(java.lang.String)">
 			<flows>
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
@@ -82,7 +82,7 @@
 				</flow>
 			</flows>
 		</method>
-		<method id="java.lang.Long parseLong(java.lang.String,int)">
+		<method id="long parseLong(java.lang.String,int)">
 			<flows>
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />


### PR DESCRIPTION
Hello,
I noticed an error in the signatures of `parseInt` and `parseLong`. It caused the taint flow to not correctly propagate across these functions.
Let me know if I am wrong.

Thanks,
Luca