### PR TITLE
The running result of droidBench in soot-infoflow-android module cannot be displayed normally.

### DIFF
--- a/soot-infoflow-android/pom.xml
+++ b/soot-infoflow-android/pom.xml
@@ -123,6 +123,16 @@
 	
 	<dependencies>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.5</version>
+		</dependency>
+		<dependency>
 			<groupId>de.tud.sse</groupId>
 			<artifactId>soot-infoflow</artifactId>
 			<version>2.9.0-SNAPSHOT</version>


### PR DESCRIPTION
when I run the test of droidBench in soot-infoflow-android module, the test result cannot be displayed normally, and the following error message is displayed:
**SLF4J: Failed to load class “org.slf4j.impl.StaticLoggerBinder”**
so I add two dependency int pom.xml, and the result can be displayed normally.