### PR TITLE
add heristic for malware

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/manifest/IManifestHandler.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/manifest/IManifestHandler.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import soot.jimple.infoflow.util.SystemClassHandler;
 
@@ -103,6 +104,12 @@ public interface IManifestHandler<A extends IActivity, S extends IService, C ext
 		Set<String> entryPoints = new HashSet<String>();
 		for (IAndroidComponent node : getAllComponents())
 			checkAndAddComponent(entryPoints, node);
+
+		if (entryPoints.isEmpty()){
+			//if no entry point is detected at all, the app is likely be malware, add all components
+			List<IAndroidComponent> allEnabled = getAllComponents().stream().filter(c -> c.isEnabled()).collect(Collectors.toList());
+			allEnabled.forEach(e->entryPoints.add(e.getNameString()));
+		}
 
 		if (app != null) {
 			String appName = app.getName();


### PR DESCRIPTION
The current heuristic to compare package name of component classes again hard-coded list is less effective when dealing with malware apps (see https://github.com/secure-software-engineering/FlowDroid/issues/240 and https://github.com/secure-software-engineering/FlowDroid/issues/171). I understand this is for the sake of performance. However, if there is no entry point can be detected according to the current heuristic, one can assume that the app is likely to be malware with system-like package name.  All enabled components should be added to the list of entry point classes. For such cases, I think it is better to analyze all than nothing. 

