### PR TITLE
Fix typo in SourcePropagationRule.java

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/SourcePropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/SourcePropagationRule.java
@@ -101,7 +101,7 @@ public class SourcePropagationRule extends AbstractTaintPropagationRule {
 		// Normally, we don't inspect source methods
 		if (!getManager().getConfig().getInspectSources() && getManager().getSourceSinkManager() != null) {
 			final SourceInfo sourceInfo = getManager().getSourceSinkManager().getSourceInfo(stmt, getManager());
-			if (sourceInfo != null && isCallbackOrReturn(sourceInfo.getDefinition()))
+			if (sourceInfo != null && !isCallbackOrReturn(sourceInfo.getDefinition()))
 				killAll.value = true;
 		}
 


### PR DESCRIPTION
Referring to c204cfaf6fb48e9b54eb81f9d2b1cad6aa8e2d5c "do not skip source methods if our source definition is on a callback or the return value", the condition should be inverted.