### PR TITLE
Properly clear data after field definition

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/source/parsers/xml/XMLSourceSinkParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/source/parsers/xml/XMLSourceSinkParser.java
@@ -304,6 +304,9 @@ public class XMLSourceSinkParser implements ISourceSinkDefinitionProvider {
 				// Start a new field and discard our old data
 				methodSignature = null;
 				fieldSignature = null;
+				baseAPs = new HashSet<>();
+				paramAPs = new ArrayList<>();
+				returnAPs = new HashSet<>();
 				description = null;
 				break;
 


### PR DESCRIPTION
The current endElement in XMLSourceSinkParser for FIELD_TAG does not clear all old data as METHOD_TAG when field definition finished, which will pollute the next definition. Fix it to properly clear all.

For example:
```xml
        <field signature="&lt;A: D E&gt;">
            <accessPath isSource="true" isSink="false" />
        </field>
        <method signature="&lt;A: B C()&gt;">
            <return>
                <accessPath isSource="true" isSink="false" />
            </return>
        </method>
```

The next definition will be polluted as source.