### PR TITLE
fix a simple comment symbol mistake on EasyTaintWrapper

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/taintWrappers/EasyTaintWrapper.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/taintWrappers/EasyTaintWrapper.java
@@ -154,7 +154,7 @@ public class EasyTaintWrapper extends AbstractTaintWrapper implements Cloneable 
 			List<String> killList = new LinkedList<String>();
 			this.includeList = new HashSet<String>();
 			while (line != null) {
-				if (!line.isEmpty() && !line.startsWith("%"))
+				if (!line.isEmpty() && !line.startsWith("#"))
 					if (line.startsWith("~"))
 						excludeList.add(line.substring(1));
 					else if (line.startsWith("-"))


### PR DESCRIPTION
In the default EasyTaintWrapper file **'EasyTaintWrapperSource.txt'**, the comment line starts with the symbol **'#'**  and I can't find the symbol '%'.