### PR TITLE
fix droidbench test apk path

### DIFF
--- a/soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/JUnitTests.java
+++ b/soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/JUnitTests.java
@@ -119,9 +119,9 @@ public class JUnitTests {
 			throw new RuntimeException("Android JAR dir not set");
 		System.out.println("Loading Android.jar files from " + androidJars);
 
-		String droidBenchDir = System.getenv("DROIDBENCH");
+		String droidBenchDir = System.getenv("DROIDBENCH")+"/apk";
 		if (droidBenchDir == null)
-			droidBenchDir = System.getProperty("DROIDBENCH");
+			droidBenchDir = System.getProperty("DROIDBENCH")+"/apk";
 		if (droidBenchDir == null) {
 			File droidBenchFile = new File("DroidBench/apk");
 			if (!droidBenchFile.exists())


### PR DESCRIPTION
Droidbench test apks in Dir DroidBench's sub dir ./apk，variable droidBenchDir in soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/JUnitTests.java miss it, so it can't find apks.