### PR TITLE
Fix StubDroid tests

### DIFF
--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/data/provider/LazySummaryProvider.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/data/provider/LazySummaryProvider.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import soot.jimple.infoflow.collect.ConcurrentHashSet;
 import soot.jimple.infoflow.methodSummary.data.summary.ClassMethodSummaries;
 import soot.jimple.infoflow.methodSummary.data.summary.ClassSummaries;
 
@@ -20,7 +21,7 @@ public class LazySummaryProvider extends XMLSummaryProvider {
 
 	protected Set<File> files = new HashSet<>();
 	protected Set<Path> pathes = new HashSet<>();
-	protected Set<String> loadableClasses = new HashSet<String>();
+	protected Set<String> loadableClasses = new ConcurrentHashSet<>();
 
 	/**
 	 * Loads a summary from a folder within the StubDroid jar file.

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/JUnitTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/JUnitTests.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import soot.jimple.infoflow.AbstractInfoflow;
 import soot.jimple.infoflow.IInfoflow;
 import soot.jimple.infoflow.Infoflow;
 import soot.jimple.infoflow.config.ConfigForTest;
@@ -152,13 +153,14 @@ public abstract class JUnitTests {
 		}
 	}
 
+	protected abstract AbstractInfoflow createInfoflowInstance();
+
 	protected IInfoflow initInfoflow() {
 		return initInfoflow(false);
 	}
 
 	protected IInfoflow initInfoflow(boolean useTaintWrapper) {
-//		IInfoflow result = new BackwardsInfoflow();
-		Infoflow result = new Infoflow();
+		IInfoflow result = createInfoflowInstance();
 		ConfigForTest testConfig = new ConfigForTest();
 		result.setSootConfig(testConfig);
 		if (useTaintWrapper) {

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/SummaryTaintWrapperTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/SummaryTaintWrapperTests.java
@@ -23,9 +23,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import soot.jimple.infoflow.BackwardsInfoflow;
-import soot.jimple.infoflow.IInfoflow;
-import soot.jimple.infoflow.InfoflowConfiguration;
+import soot.jimple.infoflow.*;
 import soot.jimple.infoflow.config.IInfoflowConfig;
 import soot.jimple.infoflow.entryPointCreators.DefaultEntryPointCreator;
 import soot.jimple.infoflow.methodSummary.data.provider.EagerSummaryProvider;
@@ -34,7 +32,7 @@ import soot.jimple.infoflow.results.InfoflowResults;
 import soot.jimple.infoflow.taintWrappers.ITaintPropagationWrapper;
 import soot.options.Options;
 
-public class SummaryTaintWrapperTests {
+public abstract class SummaryTaintWrapperTests {
 	private static String appPath, libPath;
 
 	private String[] source = new String[] {
@@ -262,9 +260,10 @@ public class SummaryTaintWrapperTests {
 		}
 	}
 
+	protected abstract AbstractInfoflow createInfoflowInstance();
+
 	protected IInfoflow initInfoflow() throws FileNotFoundException, XMLStreamException {
-		IInfoflow result = new BackwardsInfoflow();
-//		Infoflow result = new Infoflow();
+		IInfoflow result = createInfoflowInstance();
 		result.getConfig().getAccessPathConfiguration().setUseRecursiveAccessPaths(false);
 		IInfoflowConfig testConfig = new IInfoflowConfig() {
 

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/WrapperListTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/WrapperListTests.java
@@ -14,12 +14,12 @@ import soot.jimple.infoflow.Infoflow;
 import soot.jimple.infoflow.methodSummary.taintWrappers.TaintWrapperFactory;
 import soot.jimple.infoflow.taintWrappers.ITaintPropagationWrapper;
 
-public class WrapperListTests extends JUnitTests {
+public abstract class WrapperListTests extends JUnitTests {
 
 	private static File files = new File("testSummaries");
 	protected final ITaintPropagationWrapper wrapper;
 
-	public WrapperListTests() throws FileNotFoundException, XMLStreamException {
+	public WrapperListTests() {
 		wrapper = (ITaintPropagationWrapper) TaintWrapperFactory.createTaintWrapper(files);
 	}
 

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/backward/SummaryTaintWrapperTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/backward/SummaryTaintWrapperTests.java
@@ -1,0 +1,11 @@
+package soot.jimple.infoflow.test.methodSummary.junit.backward;
+
+import soot.jimple.infoflow.AbstractInfoflow;
+import soot.jimple.infoflow.BackwardsInfoflow;
+
+public class SummaryTaintWrapperTests extends soot.jimple.infoflow.test.methodSummary.junit.SummaryTaintWrapperTests {
+    @Override
+    protected AbstractInfoflow createInfoflowInstance() {
+        return new BackwardsInfoflow("", false, null);
+    }
+}

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/backward/WrapperListTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/backward/WrapperListTests.java
@@ -1,0 +1,11 @@
+package soot.jimple.infoflow.test.methodSummary.junit.backward;
+
+import soot.jimple.infoflow.AbstractInfoflow;
+import soot.jimple.infoflow.BackwardsInfoflow;
+
+public class WrapperListTests extends soot.jimple.infoflow.test.methodSummary.junit.WrapperListTests {
+    @Override
+    protected AbstractInfoflow createInfoflowInstance() {
+        return new BackwardsInfoflow("", false, null);
+    }
+}

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/forward/SummaryTaintWrapperTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/forward/SummaryTaintWrapperTests.java
@@ -1,0 +1,11 @@
+package soot.jimple.infoflow.test.methodSummary.junit.forward;
+
+import soot.jimple.infoflow.AbstractInfoflow;
+import soot.jimple.infoflow.Infoflow;
+
+public class SummaryTaintWrapperTests extends soot.jimple.infoflow.test.methodSummary.junit.SummaryTaintWrapperTests {
+    @Override
+    protected AbstractInfoflow createInfoflowInstance() {
+        return new Infoflow("", false, null);
+    }
+}

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/forward/WrapperListTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/forward/WrapperListTests.java
@@ -1,0 +1,11 @@
+package soot.jimple.infoflow.test.methodSummary.junit.forward;
+
+import soot.jimple.infoflow.AbstractInfoflow;
+import soot.jimple.infoflow.Infoflow;
+
+public class WrapperListTests extends soot.jimple.infoflow.test.methodSummary.junit.WrapperListTests {
+    @Override
+    protected AbstractInfoflow createInfoflowInstance() {
+        return new Infoflow("", false, null);
+    }
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsWrapperRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsWrapperRule.java
@@ -141,8 +141,8 @@ public class BackwardsWrapperRule extends AbstractTaintPropagationRule {
 						addAbstraction = false;
 				}
 
-				// Primitive Assignment -> set turn unit
-				boolean performAliasSearch = false;
+				// Set the turn unit on primitive assignment. Otherwise, perform an alias search.
+				boolean performAliasSearch = true;
 				if (retValTainted && leftOp != null) {
 					Type t;
 					if (leftOp instanceof FieldRef)

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsWrapperRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsWrapperRule.java
@@ -38,7 +38,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
 import soot.jimple.infoflow.util.preanalyses.SingleLiveVariableAnalysis;
 
 public class BackwardsWrapperRule extends AbstractTaintPropagationRule {
-	public static boolean DEBUG_TW = false;
 
 	public BackwardsWrapperRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
 		super(manager, zeroValue, results);
@@ -195,10 +194,6 @@ public class BackwardsWrapperRule extends AbstractTaintPropagationRule {
 			for (Abstraction abs : res)
 				if (abs != source)
 					abs.setCorrespondingCallSite(stmt);
-
-		if (DEBUG_TW)
-			System.out.println("In: " + source.toString() + "\n" + "Stmt:" + stmt.toString() + "\n"
-					+ (res == null ? "[]" : res.toString()) + "\n");
 
 		return res;
 	}


### PR DESCRIPTION
There was a small copy&paste error inside the `BackwardsWrapperPropagationRule` that lead to `performAliasSearch` being always false and thus, the alias analysis was never called.

After that fix, one of the failing tests triggered a `ConcurrentModificationException` inside the `LazySummaryProvider`, which I then fixed by using a thread-safe HashSet.