### PR TITLE
Keep the call site when shortening the abstraction chain

### DIFF
--- a/soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/CallbackTest.java
+++ b/soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/CallbackTest.java
@@ -29,6 +29,7 @@ public abstract class CallbackTest extends JUnitTests {
 		InfoflowResults res = analyzeAPKFile("Callbacks/AnonymousClass1.apk");
 		Assert.assertNotNull(res);
 		Assert.assertEquals(1, res.size()); // loc + lat, but single parameter
+		Assert.assertEquals(2, res.getResultSet().size());
 	}
 
 	@Test(timeout = 300000)

--- a/soot-infoflow-android/test/soot/jimple/infoflow/android/test/otherAPKs/AlwaysShortenTests.java
+++ b/soot-infoflow-android/test/soot/jimple/infoflow/android/test/otherAPKs/AlwaysShortenTests.java
@@ -1,0 +1,27 @@
+package soot.jimple.infoflow.android.test.otherAPKs;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+import soot.jimple.infoflow.InfoflowConfiguration;
+import soot.jimple.infoflow.results.InfoflowResults;
+
+import java.io.IOException;
+
+public class AlwaysShortenTests extends soot.jimple.infoflow.android.test.droidBench.JUnitTests {
+    @Override
+    protected TestResultMode getTestResultMode() {
+        return TestResultMode.FLOWDROID_FORWARDS;
+    }
+
+    @Test(timeout = 300000)
+    public void runTestAnonymousClass1Insensitive() throws IOException, XmlPullParserException {
+        InfoflowResults res = analyzeAPKFile("Callbacks/AnonymousClass1.apk", null, config -> {
+            config.getSolverConfiguration().setDataFlowSolver(InfoflowConfiguration.DataFlowSolver.FlowInsensitive);
+        });
+
+        Assert.assertNotNull(res);
+        Assert.assertEquals(1, res.size()); // loc + lat, but single parameter
+        Assert.assertEquals(2, res.getResultSet().size());
+    }
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/data/Abstraction.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/data/Abstraction.java
@@ -485,6 +485,18 @@ public class Abstraction implements Cloneable, FastSolverLinkedNode<Abstraction,
 	}
 
 	@Override
+	public Abstraction clone(Unit currentUnit, Unit callSite) {
+		Abstraction abs = new Abstraction(accessPath, this);
+		abs.predecessor = this;
+		abs.neighbors = null;
+		abs.currentStmt = (Stmt) currentUnit;
+		abs.correspondingCallSite = (Stmt) callSite;
+		abs.propagationPathLength = propagationPathLength + 1;
+		assert abs.equals(this);
+		return abs;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
@@ -623,8 +635,8 @@ public class Abstraction implements Cloneable, FastSolverLinkedNode<Abstraction,
 			return false;
 
 		// We should not add identical nodes as neighbors
-		if (this.predecessor == originalAbstraction.predecessor && this.currentStmt == originalAbstraction.currentStmt
-				&& this.predecessor == originalAbstraction.predecessor
+		if (this.predecessor == originalAbstraction.predecessor
+				&& this.currentStmt == originalAbstraction.currentStmt
 				&& this.correspondingCallSite == originalAbstraction.correspondingCallSite)
 			return false;
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/AbstractIFDSSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/AbstractIFDSSolver.java
@@ -1,0 +1,55 @@
+package soot.jimple.infoflow.solver;
+
+import heros.DontSynchronize;
+import soot.jimple.infoflow.solver.fastSolver.FastSolverLinkedNode;
+
+/**
+ * Common superclass of all IFDS solvers.
+ *
+ * @param <N> node
+ * @param <D> data flow fact
+ */
+public class AbstractIFDSSolver<N, D extends FastSolverLinkedNode<D, N>> {
+    @DontSynchronize("readOnly")
+    protected PredecessorShorteningMode shorteningMode = PredecessorShorteningMode.NeverShorten;
+
+    /**
+     * Sets whether abstractions on method returns shall be connected to the
+     * respective call abstractions to shortcut paths.
+     *
+     * @param mode The strategy to use for shortening predecessor paths
+     */
+    public void setPredecessorShorteningMode(PredecessorShorteningMode mode) {
+        this.shorteningMode = mode;
+    }
+
+    /**
+     * Shortens the predecessors of the first argument if configured.
+     *
+     * @param returnD data flow fact leaving the method, which predecessor chain should be shortened
+     * @param incomingD incoming data flow fact at the call site
+     * @param calleeD first data flow fact in the callee, i.e. with current statement == call site
+     * @return data flow fact with a shortened predecessor chain
+     */
+    protected D shortenPredecessors(D returnD, D incomingD, D calleeD, N currentUnit, N callSite) {
+        switch (shorteningMode) {
+            case AlwaysShorten:
+                // If we don't build a path later, we do not have to keep flows through callees.
+                // But we have to keep the call site so that we do not lose any neighbors, but
+                // skip any abstractions inside the callee. This sets the predecessor of the
+                // returned abstraction to the first abstraction in the callee.
+                if (returnD != calleeD) {
+                    D res = returnD.clone(currentUnit, callSite);
+                    res.setPredecessor(calleeD);
+                    return res;
+                }
+                break;
+            case ShortenIfEqual:
+                if (returnD.equals(incomingD))
+                    return incomingD;
+                break;
+        }
+
+        return returnD;
+    }
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/FastSolverLinkedNode.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/FastSolverLinkedNode.java
@@ -45,6 +45,13 @@ public interface FastSolverLinkedNode<D, N> extends Cloneable {
 	public D clone();
 
 	/**
+	 * Clones this data flow abstraction with the current statement and corresponding call site set
+	 *
+	 * @return A clone of the current data flow abstraction
+	 */
+	public D clone(N currentUnit, N callSite);
+
+	/**
 	 * If this abstraction supports alias analysis, this returns the active copy of
 	 * the current abstraction. Otherwise, "this" is returned.
 	 * 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/IFDSSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/IFDSSolver.java
@@ -817,7 +817,7 @@ public class IFDSSolver<N, D extends FastSolverLinkedNode<D, N>, I extends BiDiI
 	 * @param mode The strategy to use for shortening predecessor paths
 	 */
 	public void setPredecessorShorteningMode(PredecessorShorteningMode mode) {
-		// this.shorteningMode = mode;
+		this.shorteningMode = mode;
 	}
 
 	/**

--- a/soot-infoflow/src/soot/jimple/infoflow/sourcesSinks/manager/AbstractSourceSinkInfo.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/sourcesSinks/manager/AbstractSourceSinkInfo.java
@@ -51,7 +51,7 @@ abstract class AbstractSourceSinkInfo {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		SourceInfo other = (SourceInfo) obj;
+		AbstractSourceSinkInfo other = (AbstractSourceSinkInfo) obj;
 		if (definition == null) {
 			if (other.definition != null)
 				return false;

--- a/soot-infoflow/test/soot/jimple/infoflow/config/ConfigForTest.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/config/ConfigForTest.java
@@ -41,7 +41,6 @@ public class ConfigForTest implements IInfoflowConfig {
 		Options.v().set_no_bodies_for_excluded(true);
 		Options.v().set_allow_phantom_refs(true);
 		options.set_include(includeList);
-		options.set_output_format(Options.output_format_none);
 		Options.v().setPhaseOption("jb", "use-original-names:true");
 		// Options.v().setPhaseOption("cg.spark", "string-constants:true");
 		Options.v().set_ignore_classpath_errors(true);

--- a/soot-infoflow/test/soot/jimple/infoflow/test/OtherTestCode.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/OtherTestCode.java
@@ -649,19 +649,40 @@ public class OtherTestCode {
 		cm.publish(a.field1);
 	}
 
-	int id(int i) {
-		return i;
+
+	int source1() {
+		return TelephonyManager.getIMEI();
 	}
 
-	public void alwaysShortenTest(int x) {
+	int source2() {
+		return TelephonyManager.getIMEI();
+	}
+
+	int add42(int i) {
+		return i + 42;
+	}
+
+	public void alwaysShortenTest1(int x) {
 		ConnectionManager cm = new ConnectionManager();
 		int i;
 		if (x == 42) {
-			i = TelephonyManager.getIMEI();
+			i = source1();
 		} else {
-			i = TelephonyManager.getIMEI();
+			i = source2();
 		}
-		cm.publish(id(i));
+		// add42 call can be shortened at processExit()
+		cm.publish(add42(i));
+	}
+
+	public void alwaysShortenTest2(int x) {
+		int k = TelephonyManager.getIMEI();
+		System.out.println(add42(k));
+		k = 0;
+
+		ConnectionManager cm = new ConnectionManager();
+		int i = source1();
+		// add42 call can be shortened at applyEndSummaryOnCall()
+		cm.publish(add42(i));
 	}
 
 }

--- a/soot-infoflow/test/soot/jimple/infoflow/test/OtherTestCode.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/OtherTestCode.java
@@ -649,4 +649,19 @@ public class OtherTestCode {
 		cm.publish(a.field1);
 	}
 
+	int id(int i) {
+		return i;
+	}
+
+	public void alwaysShortenTest(int x) {
+		ConnectionManager cm = new ConnectionManager();
+		int i;
+		if (x == 42) {
+			i = TelephonyManager.getIMEI();
+		} else {
+			i = TelephonyManager.getIMEI();
+		}
+		cm.publish(id(i));
+	}
+
 }

--- a/soot-infoflow/test/soot/jimple/infoflow/test/junit/AlwaysShortenTests.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/junit/AlwaysShortenTests.java
@@ -1,0 +1,53 @@
+package soot.jimple.infoflow.test.junit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import soot.jimple.Stmt;
+import soot.jimple.infoflow.IInfoflow;
+import soot.jimple.infoflow.results.DataFlowResult;
+import soot.jimple.infoflow.results.ResultSourceInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AlwaysShortenTests extends JUnitTests {
+
+    private boolean pathContainsStmt(ResultSourceInfo sourceInfo, String signature) {
+        for (Stmt stmt : sourceInfo.getPath())
+            if (signature.equals(stmt.toString()))
+                return true;
+        return false;
+    }
+
+    @Test
+    public void alwaysShortenTest1() {
+        // Tests that always shortens doesn't break neighbors at the call site. See also issue 583.
+        IInfoflow infoflow = initInfoflow();
+        List<String> epoints = new ArrayList<String>();
+        epoints.add("<soot.jimple.infoflow.test.OtherTestCode: void alwaysShortenTest1(int)>");
+        infoflow.computeInfoflow(appPath, libPath, epoints, sources, sinks);
+        checkInfoflow(infoflow, 1);
+        // Make sure we found two distinct source statements
+        Assert.assertEquals(2, infoflow.getResults().getResultSet().stream()
+                .map(res -> res.getSource().getStmt()).distinct().count());
+        // and that the path was shortened
+        for (DataFlowResult res : infoflow.getResults().getResultSet()) {
+            Assert.assertFalse(pathContainsStmt(res.getSource(), "$stack2 = i + 42"));
+        }
+    }
+
+    @Test
+    public void alwaysShortenTest2() {
+        // Tests that always shortens doesn't break neighbors at the call site. See also issue 583.
+        IInfoflow infoflow = initInfoflow();
+        List<String> epoints = new ArrayList<String>();
+        epoints.add("<soot.jimple.infoflow.test.OtherTestCode: void alwaysShortenTest2(int)>");
+        infoflow.computeInfoflow(appPath, libPath, epoints, sources, sinks);
+        checkInfoflow(infoflow, 1);
+        Assert.assertEquals(1, infoflow.getResults().getResultSet().size());
+        // Make sure that the path was shortened
+        for (DataFlowResult res : infoflow.getResults().getResultSet()) {
+            Assert.assertFalse(pathContainsStmt(res.getSource(), "$stack2 = i + 42"));
+        }
+    }
+}

--- a/soot-infoflow/test/soot/jimple/infoflow/test/junit/OtherTests.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/junit/OtherTests.java
@@ -437,4 +437,14 @@ public abstract class OtherTests extends JUnitTests {
 		Assert.assertTrue(infoflow.getResults().isPathBetweenMethods(sink, sourceDeviceId));
 	}
 
+	@Test
+	public void alwaysShortenTest() {
+		// Tests that always shortens doesn't break neighbors at the call site. See also issue 583.
+		IInfoflow infoflow = initInfoflow();
+		List<String> epoints = new ArrayList<String>();
+		epoints.add("<soot.jimple.infoflow.test.OtherTestCode: void alwaysShortenTest(int)>");
+		infoflow.computeInfoflow(appPath, libPath, epoints, sources, sinks);
+		checkInfoflow(infoflow, 1);
+	}
+
 }

--- a/soot-infoflow/test/soot/jimple/infoflow/test/junit/OtherTests.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/junit/OtherTests.java
@@ -437,14 +437,4 @@ public abstract class OtherTests extends JUnitTests {
 		Assert.assertTrue(infoflow.getResults().isPathBetweenMethods(sink, sourceDeviceId));
 	}
 
-	@Test
-	public void alwaysShortenTest() {
-		// Tests that always shortens doesn't break neighbors at the call site. See also issue 583.
-		IInfoflow infoflow = initInfoflow();
-		List<String> epoints = new ArrayList<String>();
-		epoints.add("<soot.jimple.infoflow.test.OtherTestCode: void alwaysShortenTest(int)>");
-		infoflow.computeInfoflow(appPath, libPath, epoints, sources, sinks);
-		checkInfoflow(infoflow, 1);
-	}
-
 }

--- a/soot-infoflow/test/soot/jimple/infoflow/test/junit/backward/AlwaysShortenTests.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/junit/backward/AlwaysShortenTests.java
@@ -1,0 +1,28 @@
+package soot.jimple.infoflow.test.junit.backward;
+
+import soot.jimple.infoflow.AbstractInfoflow;
+import soot.jimple.infoflow.BackwardsInfoflow;
+import soot.jimple.infoflow.Infoflow;
+import soot.jimple.infoflow.InfoflowConfiguration;
+import soot.jimple.infoflow.cfg.BiDirICFGFactory;
+import soot.jimple.infoflow.solver.PredecessorShorteningMode;
+
+public class AlwaysShortenTests extends soot.jimple.infoflow.test.junit.AlwaysShortenTests {
+    class AlwaysShortenBackwardsInfoflow extends BackwardsInfoflow {
+        public AlwaysShortenBackwardsInfoflow(String androidPath, boolean forceAndroidJar, BiDirICFGFactory icfgFactory) {
+            super(androidPath, forceAndroidJar, icfgFactory);
+        }
+
+        @Override
+        protected PredecessorShorteningMode pathConfigToShorteningMode(InfoflowConfiguration.PathConfiguration pathConfiguration) {
+            return PredecessorShorteningMode.AlwaysShorten;
+        }
+    }
+
+    @Override
+    protected AbstractInfoflow createInfoflowInstance() {
+        AbstractInfoflow infoflow = new AlwaysShortenBackwardsInfoflow("", false, null);
+        infoflow.getConfig().getPathConfiguration().setPathReconstructionMode(InfoflowConfiguration.PathReconstructionMode.Fast);
+        return infoflow;
+    }
+}

--- a/soot-infoflow/test/soot/jimple/infoflow/test/junit/forward/AlwaysShortenTests.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/junit/forward/AlwaysShortenTests.java
@@ -1,0 +1,27 @@
+package soot.jimple.infoflow.test.junit.forward;
+
+import soot.jimple.infoflow.AbstractInfoflow;
+import soot.jimple.infoflow.Infoflow;
+import soot.jimple.infoflow.InfoflowConfiguration;
+import soot.jimple.infoflow.cfg.BiDirICFGFactory;
+import soot.jimple.infoflow.solver.PredecessorShorteningMode;
+
+public class AlwaysShortenTests extends soot.jimple.infoflow.test.junit.AlwaysShortenTests {
+    class AlwaysShortenInfoflow extends Infoflow {
+        public AlwaysShortenInfoflow(String androidPath, boolean forceAndroidJar, BiDirICFGFactory icfgFactory) {
+            super(androidPath, forceAndroidJar, icfgFactory);
+        }
+
+        @Override
+        protected PredecessorShorteningMode pathConfigToShorteningMode(InfoflowConfiguration.PathConfiguration pathConfiguration) {
+            return PredecessorShorteningMode.AlwaysShorten;
+        }
+    }
+
+    @Override
+    protected AbstractInfoflow createInfoflowInstance() {
+        AbstractInfoflow infoflow = new AlwaysShortenInfoflow("", false, null);
+        infoflow.getConfig().getPathConfiguration().setPathReconstructionMode(InfoflowConfiguration.PathReconstructionMode.Fast);
+        return infoflow;
+    }
+}


### PR DESCRIPTION
Should fix #583 