### PR TITLE
fixed both case Infoflow

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/Infoflow.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/Infoflow.java
@@ -159,7 +159,7 @@ public class Infoflow extends AbstractInfoflow {
 			return SourceSinkState.SOURCE;
 		else if (sinkInfo != null && sourceInfo == null)
 			return SourceSinkState.SINK;
-		else if (sourceInfo != null && sinkInfo == null)
+		else if (sourceInfo != null && sinkInfo != null)
 			return SourceSinkState.BOTH;
 		return SourceSinkState.NEITHER;
 	}


### PR DESCRIPTION
[#596](https://github.com/secure-software-engineering/FlowDroid/issues/596)

Fix the condition in `Infoflow.scanStmtForSourcesSinks` for the `Both`  case. 