### PR TITLE
Address issue #622: merge FPC into FlowDroid

### DIFF
--- a/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
+++ b/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
@@ -108,6 +108,7 @@ public class MainClass {
 	private static final String OPTION_MAX_CALLBACKS_COMPONENT = "mc";
 	private static final String OPTION_MAX_CALLBACKS_DEPTH = "md";
 	private static final String OPTION_PATH_SPECIFIC_RESULTS = "ps";
+	private static final String OPTION_MAX_THREAD_NUMBER = "mt";
 
 	// Inter-component communication
 	private static final String OPTION_ICC_MODEL = "im";
@@ -126,6 +127,7 @@ public class MainClass {
 	private static final String OPTION_IMPLICIT_FLOW_MODE = "i";
 	private static final String OPTION_STATIC_FLOW_TRACKING_MODE = "sf";
 	private static final String OPTION_DATA_FLOW_DIRECTION = "dir";
+	private static final String OPTION_GC_SLEEP_TIME = "st";
 
 	// Evaluation-specific options
 	private static final String OPTION_ANALYZE_FRAMEWORKS = "ff";
@@ -193,7 +195,8 @@ public class MainClass {
 				"Compute the taint propagation paths and not just source-to-sink connections. This is a shorthand notation for -pr fast.");
 		options.addOption(OPTION_LOG_SOURCES_SINKS, "logsourcesandsinks", false,
 				"Write the discovered sources and sinks to the log output");
-		options.addOption("mt", "maxthreadnum", true, "Limit the maximum number of threads to the given value");
+		options.addOption(OPTION_MAX_THREAD_NUMBER, "maxthreadnum", true,
+				"Limit the maximum number of threads to the given value");
 		options.addOption(OPTION_ONE_COMPONENT, "onecomponentatatime", false,
 				"Analyze one Android component at a time");
 		options.addOption(OPTION_ONE_SOURCE, "onesourceatatime", false, "Analyze one source at a time");
@@ -241,6 +244,8 @@ public class MainClass {
 				"Use the specified mode when tracking static data flows (CONTEXTFLOWSENSITIVE, CONTEXTFLOWINSENSITIVE, NONE)");
 		options.addOption(OPTION_DATA_FLOW_DIRECTION, "direction", true,
 				"Specifies the direction of the infoflow analysis (FORWARDS, BACKWARDS)");
+		options.addOption(OPTION_GC_SLEEP_TIME, "gcsleeptime", true, 
+				"Specifies the sleep time for path edge collectors in seconds");
 
 		// Evaluation-specific options
 		options.addOption(OPTION_ANALYZE_FRAMEWORKS, "analyzeframeworks", false,
@@ -790,6 +795,12 @@ public class MainClass {
 			if (maxDepth != null)
 				config.getCallbackConfig().setMaxAnalysisCallbackDepth(maxDepth);
 		}
+		{
+			Integer maxthreadnum = getIntOption(cmd, OPTION_MAX_THREAD_NUMBER);
+			if (maxthreadnum != null) {
+				config.setMaxThreadNum(maxthreadnum);
+			}
+		}
 
 		// Inter-component communication
 		if (cmd.hasOption(OPTION_ICC_NO_PURIFY))
@@ -885,6 +896,13 @@ public class MainClass {
 			if (callgraphFile != null && !callgraphFile.isEmpty()) {
 				config.getCallbackConfig().setSerializeCallbacks(true);
 				config.getCallbackConfig().setCallbacksFile(callgraphFile);
+			}
+		}
+
+		{
+			Integer sleepTime = getIntOption(cmd, OPTION_GC_SLEEP_TIME);
+			if (sleepTime != null) {
+				config.getSolverConfiguration().setSleepTime(sleepTime);
 			}
 		}
 	}

--- a/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
+++ b/soot-infoflow-cmd/src/soot/jimple/infoflow/cmd/MainClass.java
@@ -593,6 +593,8 @@ public class MainClass {
 			return DataFlowSolver.FlowInsensitive;
 		else if (solver.equalsIgnoreCase("GC"))
 			return DataFlowSolver.GarbageCollecting;
+		else if (solver.equalsIgnoreCase("FPC"))
+			return DataFlowSolver.FineGrainedGC;
 		else {
 			System.err.println(String.format("Invalid data flow solver: %s", solver));
 			throw new AbortAnalysisException();

--- a/soot-infoflow/src/soot/jimple/infoflow/AbstractInfoflow.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/AbstractInfoflow.java
@@ -704,7 +704,7 @@ public abstract class AbstractInfoflow implements IInfoflow {
 			manager = initializeInfoflowManager(sourcesSinks, iCfg, globalTaintManager);
 
 			// Create the solver peer group
-			solverPeerGroup = new GCSolverPeerGroup();
+			solverPeerGroup = new GCSolverPeerGroup<SootMethod>();
 
 			// Initialize the alias analysis
 			Abstraction zeroValue = Abstraction.getZeroAbstraction(manager.getConfig().getFlowSensitiveAliasing());
@@ -1238,7 +1238,8 @@ public abstract class AbstractInfoflow implements IInfoflow {
 			return new soot.jimple.infoflow.solver.fastSolver.flowInsensitive.InfoflowSolver(problem, executor);
 		case GarbageCollecting:
 			logger.info("Using garbage-collecting solver");
-			IInfoflowSolver solver = new soot.jimple.infoflow.solver.gcSolver.InfoflowSolver(problem, executor);
+			IInfoflowSolver solver = new soot.jimple.infoflow.solver.gcSolver.InfoflowSolver(problem, executor,
+					solverConfig.getSleepTime());
 			solverPeerGroup.addSolver(solver);
 			solver.setPeerGroup(solverPeerGroup);
 			return solver;

--- a/soot-infoflow/src/soot/jimple/infoflow/AbstractInfoflow.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/AbstractInfoflow.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import heros.solver.Pair;
 import soot.FastHierarchy;
 import soot.G;
 import soot.MethodOrMethodContext;
@@ -704,7 +705,13 @@ public abstract class AbstractInfoflow implements IInfoflow {
 			manager = initializeInfoflowManager(sourcesSinks, iCfg, globalTaintManager);
 
 			// Create the solver peer group
-			solverPeerGroup = new GCSolverPeerGroup<SootMethod>();
+			switch (manager.getConfig().getSolverConfiguration().getDataFlowSolver()) {
+			case FineGrainedGC:
+				solverPeerGroup = new GCSolverPeerGroup<Pair<SootMethod, Abstraction>>();
+				break;
+			default:
+				solverPeerGroup = new GCSolverPeerGroup<SootMethod>();
+			}
 
 			// Initialize the alias analysis
 			Abstraction zeroValue = Abstraction.getZeroAbstraction(manager.getConfig().getFlowSensitiveAliasing());
@@ -1243,6 +1250,13 @@ public abstract class AbstractInfoflow implements IInfoflow {
 			solverPeerGroup.addSolver(solver);
 			solver.setPeerGroup(solverPeerGroup);
 			return solver;
+		case FineGrainedGC:
+			logger.info("Using fine-grained garbage-collecting solver");
+			IInfoflowSolver fgSolver = new soot.jimple.infoflow.solver.gcSolver.fpc.InfoflowSolver(problem, executor,
+					solverConfig.getSleepTime());
+			solverPeerGroup.addSolver(fgSolver);
+			fgSolver.setPeerGroup(solverPeerGroup);
+			return fgSolver;
 		default:
 			throw new RuntimeException("Unsupported data flow solver");
 		}

--- a/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
@@ -133,7 +133,12 @@ public class InfoflowConfiguration {
 		/**
 		 * Use the garbage-collecting solver
 		 */
-		GarbageCollecting
+		GarbageCollecting,
+
+		/**
+		 * Use the fine-grained GC solver
+		 * */
+		FineGrainedGC,
 	}
 
 	public static enum DataFlowDirection {

--- a/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
@@ -971,6 +971,7 @@ public class InfoflowConfiguration {
 		private int maxJoinPointAbstractions = 10;
 		private int maxCalleesPerCallSite = 75;
 		private int maxAbstractionPathLength = 100;
+		private int sleepTime = 1;
 
 		/**
 		 * Copies the settings of the given configuration into this configuration object
@@ -1082,6 +1083,24 @@ public class InfoflowConfiguration {
 		 */
 		public void setMaxAbstractionPathLength(int maxAbstractionPathLength) {
 			this.maxAbstractionPathLength = maxAbstractionPathLength;
+		}
+
+		/**
+		 * Sets the sleep time of garbage colletors
+		 * 
+		 * @param sleeptime The interval in second for the path edge collection
+		 */
+		public void setSleepTime(int sleeptime) {
+			this.sleepTime = sleeptime;
+		}
+
+		/**
+		 * Gets the sleep time of garbage colletors
+		 * 
+		 * @return The interval in second for the path edge collection
+		 */
+		public int getSleepTime() {
+			return this.sleepTime;
 		}
 
 		@Override

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AbstractGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AbstractGarbageCollector.java
@@ -11,15 +11,15 @@ import soot.util.ConcurrentHashMultiMap;
  * @author Steven Arzt
  *
  */
-public abstract class AbstractGarbageCollector<N, D> implements IGarbageCollector<N, D> {
+public abstract class AbstractGarbageCollector<N, D, A> implements IGarbageCollector<N, D> {
 
 	protected final BiDiInterproceduralCFG<N, SootMethod> icfg;
-	protected final IGCReferenceProvider<D, N> referenceProvider;
-	protected final ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions;
+	protected final IGCReferenceProvider<A> referenceProvider;
+	protected final ConcurrentHashMultiMap<A, PathEdge<N, D>> jumpFunctions;
 
 	public AbstractGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
-			ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions,
-			IGCReferenceProvider<D, N> referenceProvider) {
+			ConcurrentHashMultiMap<A, PathEdge<N, D>> jumpFunctions,
+			IGCReferenceProvider<A> referenceProvider) {
 		this.icfg = icfg;
 		this.referenceProvider = referenceProvider;
 		this.jumpFunctions = jumpFunctions;
@@ -27,7 +27,7 @@ public abstract class AbstractGarbageCollector<N, D> implements IGarbageCollecto
 	}
 
 	public AbstractGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
-			ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions) {
+			ConcurrentHashMultiMap<A, PathEdge<N, D>> jumpFunctions) {
 		this.icfg = icfg;
 		this.referenceProvider = createReferenceProvider();
 		this.jumpFunctions = jumpFunctions;
@@ -46,8 +46,10 @@ public abstract class AbstractGarbageCollector<N, D> implements IGarbageCollecto
 	 * 
 	 * @return The new reference provider
 	 */
-	protected IGCReferenceProvider<D, N> createReferenceProvider() {
-		return new OnDemandReferenceProvider<>(icfg);
+	protected abstract IGCReferenceProvider<A> createReferenceProvider();
+
+	protected long getRemainingPathEdgeCount() {
+		return jumpFunctions.values().size();
 	}
 
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AbstractReferenceProvider.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AbstractReferenceProvider.java
@@ -14,7 +14,7 @@ import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
  * @author Steven Arzt
  *
  */
-public abstract class AbstractReferenceProvider<D, N> implements IGCReferenceProvider<D, N> {
+public abstract class AbstractReferenceProvider<A, N> implements IGCReferenceProvider<A> {
 
 	protected final BiDiInterproceduralCFG<N, SootMethod> icfg;
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AggressiveGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AggressiveGarbageCollector.java
@@ -17,7 +17,7 @@ import soot.util.ConcurrentHashMultiMap;
  * @author Steven Arzt
  *
  */
-public class AggressiveGarbageCollector<N, D> extends AbstractGarbageCollector<N, D> {
+public class AggressiveGarbageCollector<N, D> extends AbstractGarbageCollector<N, D, SootMethod> {
 
 	private final AtomicInteger gcedMethods = new AtomicInteger();
 
@@ -55,7 +55,7 @@ public class AggressiveGarbageCollector<N, D> extends AbstractGarbageCollector<N
 	}
 
 	@Override
-	public int getGcedMethods() {
+	public int getGcedAbstractions() {
 		return gcedMethods.get();
 	}
 
@@ -63,6 +63,11 @@ public class AggressiveGarbageCollector<N, D> extends AbstractGarbageCollector<N
 	public int getGcedEdges() {
 		// We don't keep track of individual edges
 		return 0;
+	}
+
+	@Override
+	protected IGCReferenceProvider<SootMethod> createReferenceProvider() {
+		return new OnDemandReferenceProvider<>(icfg);
 	}
 
 	/**

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AheadOfTimeReferenceProvider.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/AheadOfTimeReferenceProvider.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import soot.Scene;
 import soot.SootClass;
 import soot.SootMethod;
-import soot.jimple.infoflow.solver.fastSolver.FastSolverLinkedNode;
 import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
 import soot.util.HashMultiMap;
 import soot.util.MultiMap;
@@ -18,7 +17,7 @@ import soot.util.MultiMap;
  * 
  * @author Steven Arzt
  */
-public class AheadOfTimeReferenceProvider<D, N> extends AbstractReferenceProvider<D, N> {
+public class AheadOfTimeReferenceProvider<N> extends AbstractReferenceProvider<SootMethod, N> {
 
 	private final MultiMap<SootMethod, SootMethod> methodToCallees = new HashMultiMap<>();
 
@@ -33,7 +32,7 @@ public class AheadOfTimeReferenceProvider<D, N> extends AbstractReferenceProvide
 	}
 
 	@Override
-	public Set<SootMethod> getMethodReferences(SootMethod method, FastSolverLinkedNode<D, N> context) {
+	public Set<SootMethod> getAbstractionReferences(SootMethod method) {
 		return methodToCallees.get(method);
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/DefaultGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/DefaultGarbageCollector.java
@@ -11,7 +11,7 @@ import soot.util.ConcurrentHashMultiMap;
  * @author Steven Arzt
  *
  */
-public class DefaultGarbageCollector<N, D> extends AbstractReferenceCountingGarbageCollector<N, D> {
+public class DefaultGarbageCollector<N, D> extends MethodLevelReferenceCountingGarbageCollector<N, D> {
 
 	public DefaultGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
 			ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions) {
@@ -20,7 +20,7 @@ public class DefaultGarbageCollector<N, D> extends AbstractReferenceCountingGarb
 
 	public DefaultGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
 			ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions,
-			IGCReferenceProvider<D, N> referenceProvider) {
+			IGCReferenceProvider<SootMethod> referenceProvider) {
 		super(icfg, jumpFunctions, referenceProvider);
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/GCSolverPeerGroup.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/GCSolverPeerGroup.java
@@ -8,9 +8,9 @@ import soot.jimple.infoflow.solver.SolverPeerGroup;
  * @author Steven Arzt
  *
  */
-public class GCSolverPeerGroup extends SolverPeerGroup {
+public class GCSolverPeerGroup<A> extends SolverPeerGroup {
 
-	private GarbageCollectorPeerGroup gcPeerGroup = null;
+	private GarbageCollectorPeerGroup<A> gcPeerGroup = null;
 
 	public GCSolverPeerGroup() {
 	}
@@ -20,9 +20,9 @@ public class GCSolverPeerGroup extends SolverPeerGroup {
 	 * 
 	 * @return The garbage collector peer group
 	 */
-	public GarbageCollectorPeerGroup getGCPeerGroup() {
+	public GarbageCollectorPeerGroup<A> getGCPeerGroup() {
 		if (gcPeerGroup == null)
-			gcPeerGroup = new GarbageCollectorPeerGroup();
+			gcPeerGroup = new GarbageCollectorPeerGroup<>();
 		return gcPeerGroup;
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/GarbageCollectorPeerGroup.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/GarbageCollectorPeerGroup.java
@@ -1,9 +1,7 @@
 package soot.jimple.infoflow.solver.gcSolver;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-
-import soot.SootMethod;
 
 /**
  * Set of multiple garbage collectors that share a set of active dependencies
@@ -11,25 +9,32 @@ import soot.SootMethod;
  * @author Steven Arzt
  *
  */
-public class GarbageCollectorPeerGroup implements IGarbageCollectorPeer {
+public class GarbageCollectorPeerGroup<A> implements IGarbageCollectorPeer<A> {
 
-	private final Collection<IGarbageCollectorPeer> peers;
+	private final Collection<IGarbageCollectorPeer<A>> peers;
 
 	public GarbageCollectorPeerGroup() {
-		this.peers = new HashSet<>();
+		this.peers = new ArrayList<>();
 	}
 
-	public GarbageCollectorPeerGroup(Collection<IGarbageCollectorPeer> peers) {
+	public GarbageCollectorPeerGroup(Collection<IGarbageCollectorPeer<A>> peers) {
 		this.peers = peers;
 	}
 
 	@Override
-	public boolean hasActiveDependencies(SootMethod method) {
-		for (IGarbageCollectorPeer peer : peers) {
-			if (peer.hasActiveDependencies(method))
+	public boolean hasActiveDependencies(A abstraction) {
+		for (IGarbageCollectorPeer<A> peer : peers) {
+			if (peer.hasActiveDependencies(abstraction))
 				return true;
 		}
 		return false;
+	}
+
+	@Override
+	public void notifySolverTerminated() {
+		for(IGarbageCollectorPeer<A> peer : peers) {
+			peer.notifySolverTerminated();
+		}
 	}
 
 	/**
@@ -37,7 +42,7 @@ public class GarbageCollectorPeerGroup implements IGarbageCollectorPeer {
 	 * 
 	 * @param peer The garbage collector to add
 	 */
-	public void addGarbageCollector(IGarbageCollectorPeer peer) {
+	public void addGarbageCollector(IGarbageCollectorPeer<A> peer) {
 		this.peers.add(peer);
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IGCReferenceProvider.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IGCReferenceProvider.java
@@ -2,27 +2,23 @@ package soot.jimple.infoflow.solver.gcSolver;
 
 import java.util.Set;
 
-import soot.SootMethod;
-import soot.jimple.infoflow.solver.fastSolver.FastSolverLinkedNode;
-
 /**
  * Interface for all implementations that can provide reference counting. These
- * classes answer the following question: Given a method X, in which methods can
+ * classes answer the following question: Given an abstraction X, in which abstractions can
  * the solver transitively spawn new analysis tasks starting from X?
  * 
  * @author Steven Arzt
  *
  */
-public interface IGCReferenceProvider<D, N> {
+public interface IGCReferenceProvider<A> {
 
 	/**
-	 * Given a method and a context, gets the set of methods that in which the
+	 * Given an abstraction, gets the set of abstractions that in which the
 	 * solver can transitively spawn new analysis tasks
 	 * 
-	 * @param method
-	 * @param context
+	 * @param abstraction
 	 * @return
 	 */
-	public Set<SootMethod> getMethodReferences(SootMethod method, FastSolverLinkedNode<D, N> context);
+	public Set<A> getAbstractionReferences(A abstraction);
 
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IGarbageCollector.java
@@ -37,7 +37,7 @@ public interface IGarbageCollector<N, D> {
 	 * @return The number of methods for which taint abstractions were removed
 	 *         during garbage collection
 	 */
-	public int getGcedMethods();
+	public int getGcedAbstractions();
 
 	/**
 	 * Gets the number of taint abstractions that were removed during garbage

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IGarbageCollectorPeer.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IGarbageCollectorPeer.java
@@ -1,24 +1,23 @@
 package soot.jimple.infoflow.solver.gcSolver;
 
-import soot.SootMethod;
-
 /**
  * A garbage collector that can operate as part of a peer group
  * 
  * @author Steven Arzt
  *
  */
-public interface IGarbageCollectorPeer {
+public interface IGarbageCollectorPeer<A> {
 
 	/**
-	 * Checks whether the given method has any open dependencies in any of the
+	 * Checks whether the given abstraction has any open dependencies in any of the
 	 * solvers that are members of this peer group that prevent its jump functions
 	 * from being garbage collected
 	 * 
-	 * @param method The method to check
-	 * @return True it the method has active dependencies and thus cannot be
+	 * @param abstraction The abstraction to check
+	 * @return True if the abstraction has active dependencies and thus cannot be
 	 *         garbage-collected, false otherwise
 	 */
-	public boolean hasActiveDependencies(SootMethod method);
+	public boolean hasActiveDependencies(A abstraction);
 
+	public void notifySolverTerminated();
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/InfoflowSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/InfoflowSolver.java
@@ -42,8 +42,8 @@ public class InfoflowSolver extends IFDSSolver<Unit, Abstraction, BiDiInterproce
 	private IFollowReturnsPastSeedsHandler followReturnsPastSeedsHandler = null;
 	private final AbstractInfoflowProblem problem;
 
-	public InfoflowSolver(AbstractInfoflowProblem problem, InterruptableExecutor executor) {
-		super(problem);
+	public InfoflowSolver(AbstractInfoflowProblem problem, InterruptableExecutor executor, int sleepTime) {
+		super(problem, sleepTime);
 		this.problem = problem;
 		this.executor = executor;
 		problem.setSolver(this);

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/MethodLevelReferenceCountingGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/MethodLevelReferenceCountingGarbageCollector.java
@@ -1,0 +1,78 @@
+package soot.jimple.infoflow.solver.gcSolver;
+
+import heros.solver.PathEdge;
+import soot.SootMethod;
+import soot.jimple.infoflow.collect.ConcurrentCountingMap;
+import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
+import soot.util.ConcurrentHashMultiMap;
+
+import java.util.Set;
+
+public class MethodLevelReferenceCountingGarbageCollector<N, D>
+		extends AbstractReferenceCountingGarbageCollector<N, D, SootMethod> {
+	public MethodLevelReferenceCountingGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions,
+			IGCReferenceProvider<SootMethod> referenceProvider) {
+		super(icfg, jumpFunctions, referenceProvider);
+	}
+
+	public MethodLevelReferenceCountingGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<SootMethod, PathEdge<N, D>> jumpFunctions) {
+		super(icfg, jumpFunctions);
+	}
+
+	/**
+	 * Checks whether the given method has any open dependencies that prevent its
+	 * jump functions from being garbage collected
+	 *
+	 * @param method           The method to check
+	 * @param referenceCounter The counter that keeps track of active references to
+	 *                         taint abstractions
+	 * @return True it the method has active dependencies and thus cannot be
+	 *         garbage-collected, false otherwise
+	 */
+	private boolean hasActiveDependencies(SootMethod method, ConcurrentCountingMap<SootMethod> referenceCounter) {
+		int changeCounter = -1;
+		do {
+			// Update the change counter for the next round
+			changeCounter = referenceCounter.getChangeCounter();
+
+			// Check the method itself
+			if (referenceCounter.get(method) > 0)
+				return true;
+
+			// Check the transitive callees
+			Set<SootMethod> references = referenceProvider.getAbstractionReferences(method);
+			for (SootMethod ref : references) {
+				if (referenceCounter.get(ref) > 0)
+					return true;
+			}
+		} while (checkChangeCounter && changeCounter != referenceCounter.getChangeCounter());
+		return false;
+	}
+
+	@Override
+	public boolean hasActiveDependencies(SootMethod method) {
+		return hasActiveDependencies(method, jumpFnCounter);
+	}
+
+	@Override
+	protected SootMethod genAbstraction(PathEdge<N, D> edge) {
+		return icfg.getMethodOf(edge.getTarget());
+	}
+
+	@Override
+	public void gc() {
+
+	}
+
+	@Override
+	public void notifySolverTerminated() {
+
+	}
+
+	@Override
+	protected IGCReferenceProvider<SootMethod> createReferenceProvider() {
+		return new OnDemandReferenceProvider<>(icfg);
+	}
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/NullGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/NullGarbageCollector.java
@@ -1,6 +1,7 @@
 package soot.jimple.infoflow.solver.gcSolver;
 
 import heros.solver.PathEdge;
+import soot.SootMethod;
 
 /**
  * Mock implementation for a garbage collector that does nothing
@@ -26,7 +27,7 @@ public class NullGarbageCollector<N, D> implements IGarbageCollector<N, D> {
 	}
 
 	@Override
-	public int getGcedMethods() {
+	public int getGcedAbstractions() {
 		return 0;
 	}
 
@@ -37,6 +38,10 @@ public class NullGarbageCollector<N, D> implements IGarbageCollector<N, D> {
 
 	@Override
 	public void notifySolverTerminated() {
+	}
+
+	public void setPeerGroup(GarbageCollectorPeerGroup<SootMethod> peerGroup) {
+		// do nothing.
 	}
 
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/OnDemandReferenceProvider.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/OnDemandReferenceProvider.java
@@ -8,7 +8,6 @@ import com.google.common.cache.LoadingCache;
 import heros.SynchronizedBy;
 import heros.solver.IDESolver;
 import soot.SootMethod;
-import soot.jimple.infoflow.solver.fastSolver.FastSolverLinkedNode;
 import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
 
 /**
@@ -20,7 +19,7 @@ import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
  * @param <D>
  * @param <N>
  */
-public class OnDemandReferenceProvider<D, N> extends AbstractReferenceProvider<D, N> {
+public class OnDemandReferenceProvider<N> extends AbstractReferenceProvider<SootMethod, N> {
 
 	@SynchronizedBy("by use of synchronized LoadingCache class")
 	protected final LoadingCache<SootMethod, Set<SootMethod>> methodToReferences = IDESolver.DEFAULT_CACHE_BUILDER
@@ -38,7 +37,7 @@ public class OnDemandReferenceProvider<D, N> extends AbstractReferenceProvider<D
 	}
 
 	@Override
-	public Set<SootMethod> getMethodReferences(SootMethod method, FastSolverLinkedNode<D, N> context) {
+	public Set<SootMethod> getAbstractionReferences(SootMethod method) {
 		return methodToReferences.getUnchecked(method);
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/AbstrationDependencyGraph.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/AbstrationDependencyGraph.java
@@ -1,0 +1,100 @@
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import heros.solver.Pair;
+import soot.SootMethod;
+import soot.jimple.infoflow.collect.ConcurrentHashSet;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class AbstrationDependencyGraph<D> implements IGraph<Pair<SootMethod, D>> {
+	private final ReentrantLock lock = new ReentrantLock();
+	private final Set<Pair<SootMethod, D>> nodes = new ConcurrentHashSet<>();
+	private final Map<Pair<SootMethod, D>, Set<Pair<SootMethod, D>>> succMap = new ConcurrentHashMap<>();
+	private final Map<Pair<SootMethod, D>, Set<Pair<SootMethod, D>>> predMap = new ConcurrentHashMap<>();
+
+	@Override
+	public Set<Pair<SootMethod, D>> getNodes() {
+		return nodes;
+	}
+
+	@Override
+	public Set<Pair<SootMethod, D>> succsOf(Pair<SootMethod, D> node) {
+		return succMap.getOrDefault(node, Collections.emptySet());
+	}
+
+	@Override
+	public Set<Pair<SootMethod, D>> predsOf(Pair<SootMethod, D> node) {
+		return predMap.getOrDefault(node, Collections.emptySet());
+	}
+
+	@Override
+	public void addNode(Pair<SootMethod, D> node) {
+		nodes.add(node);
+	}
+
+	@Override
+	public void addEdge(Pair<SootMethod, D> n1, Pair<SootMethod, D> n2) {
+		addNode(n1);
+		addNode(n2);
+		succMap.computeIfAbsent(n1, k -> new ConcurrentHashSet<>()).add(n2);
+		predMap.computeIfAbsent(n2, k -> new ConcurrentHashSet<>()).add(n1);
+	}
+
+	@Override
+	public boolean contains(Pair<SootMethod, D> node) {
+		return nodes.contains(node);
+	}
+
+	@Override
+	public void removeEdge(Pair<SootMethod, D> n1, Pair<SootMethod, D> n2) {
+		succsOf(n1).remove(n2);
+		predsOf(n2).remove(n1);
+	}
+
+	@Override
+	public void remove(Pair<SootMethod, D> node) {
+		nodes.remove(node);
+		for (Pair<SootMethod, D> pred : predsOf(node)) {
+			removeEdge(pred, node);
+		}
+		for (Pair<SootMethod, D> succ : succsOf(node)) {
+			removeEdge(node, succ);
+		}
+	}
+
+	public void lock() {
+		lock.lock();
+	}
+
+	public void unlock() {
+		if (lock.isHeldByCurrentThread()) {
+			lock.unlock();
+		}
+	}
+
+	public int nodeSize() {
+		return this.nodes.size();
+	}
+
+	public int edgeSize() {
+		int ret = 0;
+		for (Set<Pair<SootMethod, D>> vs : succMap.values()) {
+			ret += vs.size();
+		}
+		return ret;
+	}
+
+	public Set<Pair<SootMethod, D>> reachableClosure(Pair<SootMethod, D> source) {
+		final Set<Pair<SootMethod, D>> visited = new ConcurrentHashSet<>();
+		final Deque<Pair<SootMethod, D>> stack = new ArrayDeque<>();
+		stack.push(source);
+		while (!stack.isEmpty()) {
+			final Pair<SootMethod, D> node = stack.pop();
+			visited.add(node);
+			succsOf(node).stream().filter(n -> !visited.contains(n)).forEach(stack::push);
+		}
+		return visited;
+	}
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/AggressiveGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/AggressiveGarbageCollector.java
@@ -1,0 +1,41 @@
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import heros.solver.Pair;
+import heros.solver.PathEdge;
+import soot.SootMethod;
+import soot.jimple.infoflow.solver.gcSolver.IGCReferenceProvider;
+import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
+import soot.util.ConcurrentHashMultiMap;
+
+public class AggressiveGarbageCollector<N, D> extends FineGrainedReferenceCountingGarbageCollector<N, D> {
+	public AggressiveGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<Pair<SootMethod, D>, PathEdge<N, D>> jumpFunctions,
+			IGCReferenceProvider<Pair<SootMethod, D>> referenceProvider) {
+		super(icfg, jumpFunctions, referenceProvider);
+	}
+
+	public AggressiveGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<Pair<SootMethod, D>, PathEdge<N, D>> jumpFunctions) {
+		super(icfg, jumpFunctions);
+	}
+
+	@Override
+	protected IGCReferenceProvider<Pair<SootMethod, D>> createReferenceProvider() {
+		return null;
+	}
+
+	@Override
+	public boolean hasActiveDependencies(Pair<SootMethod, D> abstraction) {
+		int changeCounter = -1;
+		do {
+			// Update the change counter for the next round
+			changeCounter = jumpFnCounter.getChangeCounter();
+
+			// Check the method itself
+			if (jumpFnCounter.get(abstraction) > 0)
+				return true;
+
+		} while (checkChangeCounter && changeCounter != jumpFnCounter.getChangeCounter());
+		return false;
+	}
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/FineGrainedReferenceCountingGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/FineGrainedReferenceCountingGarbageCollector.java
@@ -1,0 +1,131 @@
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import heros.solver.Pair;
+import heros.solver.PathEdge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import soot.SootMethod;
+import soot.jimple.infoflow.solver.gcSolver.AbstractReferenceCountingGarbageCollector;
+import soot.jimple.infoflow.solver.gcSolver.IGCReferenceProvider;
+import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
+import soot.util.ConcurrentHashMultiMap;
+
+public abstract class FineGrainedReferenceCountingGarbageCollector<N, D>
+		extends AbstractReferenceCountingGarbageCollector<N, D, Pair<SootMethod, D>> {
+	protected static final Logger logger = LoggerFactory.getLogger(FineGrainedReferenceCountingGarbageCollector.class);
+
+	public FineGrainedReferenceCountingGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<Pair<SootMethod, D>, PathEdge<N, D>> jumpFunctions,
+			IGCReferenceProvider<Pair<SootMethod, D>> referenceProvider) {
+		super(icfg, jumpFunctions, referenceProvider);
+	}
+
+	public FineGrainedReferenceCountingGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<Pair<SootMethod, D>, PathEdge<N, D>> jumpFunctions) {
+		super(icfg, jumpFunctions);
+	}
+
+	private class GCThread extends Thread {
+
+		private boolean finished = false;
+
+		public GCThread() {
+			setName("Fine-grained aggressive IFDS Garbage Collector");
+		}
+
+		@Override
+		public void run() {
+			while (!finished) {
+				gcImmediate();
+
+				if (sleepTimeSeconds > 0) {
+					try {
+						Thread.sleep(sleepTimeSeconds * 1000);
+					} catch (InterruptedException e) {
+						break;
+					}
+				}
+			}
+		}
+
+		/**
+		 * Notifies the thread to finish its current garbage collection and then
+		 * terminate
+		 */
+		public void finish() {
+			finished = true;
+			interrupt();
+		}
+
+	}
+
+	protected int sleepTimeSeconds = 1;
+	protected int maxPathEdgeCount = 0;
+	protected int maxMemoryConsumption = 0;
+
+	protected GCThread gcThread;
+
+	@Override
+	protected void initialize() {
+		super.initialize();
+
+		// Start the garbage collection thread
+		gcThread = new GCThread();
+		gcThread.start();
+	}
+
+	@Override
+	public void gc() {
+		// nothing to do here
+	}
+
+	@Override
+	public void notifySolverTerminated() {
+		gcImmediate();
+
+		logger.info(String.format("GC removes %d abstractions", getGcedAbstractions()));
+		logger.info(String.format("GC removes %d path edges", getGcedEdges()));
+		logger.info(String.format("Remaining Path edges count is %d", getRemainingPathEdgeCount()));
+		logger.info(String.format("Recorded Maximum Path edges count is %d", getMaxPathEdgeCount()));
+		logger.info(String.format("Recorded Maximum memory consumption is %d", getMaxMemoryConsumption()));
+		gcThread.finish();
+	}
+
+	/**
+	 * Sets the time to wait between garbage collection cycles in seconds
+	 *
+	 * @param sleepTimeSeconds The time to wait between GC cycles in seconds
+	 */
+	public void setSleepTimeSeconds(int sleepTimeSeconds) {
+		this.sleepTimeSeconds = sleepTimeSeconds;
+	}
+
+	private int getUsedMemory() {
+		Runtime runtime = Runtime.getRuntime();
+		return (int) Math.round((runtime.totalMemory() - runtime.freeMemory()) / 1E6);
+	}
+
+	public long getMaxPathEdgeCount() {
+		return this.maxPathEdgeCount;
+	}
+
+	public int getMaxMemoryConsumption() {
+		return this.maxMemoryConsumption;
+	}
+
+	@Override
+	protected void onAfterRemoveEdges() {
+		int pec = 0;
+		for (Integer i : jumpFnCounter.values()) {
+			pec += i;
+		}
+		this.maxPathEdgeCount = Math.max(this.maxPathEdgeCount, pec);
+		this.maxMemoryConsumption = Math.max(this.maxMemoryConsumption, getUsedMemory());
+	}
+
+	@Override
+	protected Pair<SootMethod, D> genAbstraction(PathEdge<N, D> edge) {
+		SootMethod method = icfg.getMethodOf(edge.getTarget());
+		return new Pair<>(method, edge.factAtSource());
+	}
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/IFDSSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/IFDSSolver.java
@@ -1,0 +1,977 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Eric Bodden.
+ * Copyright (c) 2013 Tata Consultancy Services & Ecole Polytechnique de Montreal
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v2.1
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * 
+ * Contributors:
+ *     Eric Bodden - initial API and implementation
+ *     Marc-Andre Laverdiere-Papineau - Fixed race condition
+ *     Steven Arzt - Created FastSolver implementation
+ ******************************************************************************/
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+
+import heros.DontSynchronize;
+import heros.FlowFunction;
+import heros.FlowFunctionCache;
+import heros.FlowFunctions;
+import heros.IFDSTabulationProblem;
+import heros.SynchronizedBy;
+import heros.ZeroedFlowFunctions;
+import heros.solver.Pair;
+import heros.solver.PathEdge;
+import soot.SootMethod;
+import soot.Unit;
+import soot.jimple.infoflow.collect.MyConcurrentHashMap;
+import soot.jimple.infoflow.memory.IMemoryBoundedSolver;
+import soot.jimple.infoflow.memory.ISolverTerminationReason;
+import soot.jimple.infoflow.solver.AbstractIFDSSolver;
+import soot.jimple.infoflow.solver.EndSummary;
+import soot.jimple.infoflow.solver.SolverPeerGroup;
+import soot.jimple.infoflow.solver.executors.InterruptableExecutor;
+import soot.jimple.infoflow.solver.executors.SetPoolExecutor;
+import soot.jimple.infoflow.solver.fastSolver.FastSolverLinkedNode;
+import soot.jimple.infoflow.solver.gcSolver.GCSolverPeerGroup;
+import soot.jimple.infoflow.solver.gcSolver.IGarbageCollector;
+import soot.jimple.infoflow.solver.memory.IMemoryManager;
+import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
+import soot.util.ConcurrentHashMultiMap;
+
+/**
+ * A solver for an {@link IFDSTabulationProblem}. This solver is not based on
+ * the IDESolver implementation in Heros for performance reasons.
+ * 
+ * @param <N> The type of nodes in the interprocedural control-flow graph.
+ *            Typically {@link Unit}.
+ * @param <D> The type of data-flow facts to be computed by the tabulation
+ *            problem.
+ * @param <I> The type of inter-procedural control-flow graph being used.
+ * @see IFDSTabulationProblem
+ */
+public class IFDSSolver<N, D extends FastSolverLinkedNode<D, N>, I extends BiDiInterproceduralCFG<N, SootMethod>>
+		extends AbstractIFDSSolver<N, D> implements IMemoryBoundedSolver {
+
+	public static CacheBuilder<Object, Object> DEFAULT_CACHE_BUILDER = CacheBuilder.newBuilder()
+			.concurrencyLevel(Runtime.getRuntime().availableProcessors()).initialCapacity(10000).softValues();
+
+	protected static final Logger logger = LoggerFactory.getLogger(IFDSSolver.class);
+
+	// enable with -Dorg.slf4j.simpleLogger.defaultLogLevel=trace
+	public static final boolean DEBUG = logger.isDebugEnabled();
+
+	protected InterruptableExecutor executor;
+
+	@DontSynchronize("only used by single thread")
+	protected int numThreads;
+
+	@SynchronizedBy("thread safe data structure, consistent locking when used")
+	protected ConcurrentHashMultiMap<Pair<SootMethod, D>, PathEdge<N, D>> jumpFunctions = new ConcurrentHashMultiMap<>();
+
+	@SynchronizedBy("thread safe data structure")
+	protected volatile IGarbageCollector<N, D> garbageCollector;
+
+	@SynchronizedBy("thread safe data structure, only modified internally")
+	protected final I icfg;
+
+	// stores summaries that were queried before they were computed
+	// see CC 2010 paper by Naeem, Lhotak and Rodriguez
+	@SynchronizedBy("consistent lock on 'incoming'")
+	protected final MyConcurrentHashMap<Pair<SootMethod, D>, Map<EndSummary<N, D>, EndSummary<N, D>>> endSummary = new MyConcurrentHashMap<>();
+
+	// edges going along calls
+	// see CC 2010 paper by Naeem, Lhotak and Rodriguez
+	@SynchronizedBy("consistent lock on field")
+	protected final ConcurrentHashMultiMap<Pair<SootMethod, D>, IncomingRecord<N, D>> incoming = new ConcurrentHashMultiMap<>();
+
+	@DontSynchronize("stateless")
+	protected final FlowFunctions<N, D, SootMethod> flowFunctions;
+
+	@DontSynchronize("only used by single thread")
+	protected final Map<N, Set<D>> initialSeeds;
+
+	@SynchronizedBy("thread safe data structure")
+	public LongAdder propagationCount = new LongAdder();
+
+	@DontSynchronize("stateless")
+	protected final D zeroValue;
+
+	@DontSynchronize("readOnly")
+	protected final FlowFunctionCache<N, D, SootMethod> ffCache;
+
+	@DontSynchronize("readOnly")
+	protected final boolean followReturnsPastSeeds;
+
+	@DontSynchronize("readOnly")
+	private int maxJoinPointAbstractions = -1;
+
+	@DontSynchronize("readOnly")
+	protected IMemoryManager<D, N> memoryManager = null;
+
+	protected boolean solverId;
+
+	private Set<IMemoryBoundedSolverStatusNotification> notificationListeners = new HashSet<>();
+	private ISolverTerminationReason killFlag = null;
+
+	private int maxCalleesPerCallSite = 75;
+	private int maxAbstractionPathLength = 100;
+
+	protected SolverPeerGroup solverPeerGroup;
+
+	protected AbstrationDependencyGraph<D> abstDependencyGraph;
+	protected int sleepTime = 1;
+
+	/**
+	 * Creates a solver for the given problem, which caches flow functions and edge
+	 * functions. The solver must then be started by calling {@link #solve()}.
+	 */
+	public IFDSSolver(IFDSTabulationProblem<N, D, SootMethod, I> tabulationProblem, int sleepTime) {
+		this(tabulationProblem, DEFAULT_CACHE_BUILDER);
+		this.sleepTime = sleepTime;
+	}
+
+	/**
+	 * Creates a solver for the given problem, constructing caches with the given
+	 * {@link CacheBuilder}. The solver must then be started by calling
+	 * {@link #solve()}.
+	 * 
+	 * @param tabulationProblem        The tabulation problem to solve
+	 * @param flowFunctionCacheBuilder A valid {@link CacheBuilder} or
+	 *                                 <code>null</code> if no caching is to be used
+	 *                                 for flow functions.
+	 */
+	public IFDSSolver(IFDSTabulationProblem<N, D, SootMethod, I> tabulationProblem,
+			@SuppressWarnings("rawtypes") CacheBuilder flowFunctionCacheBuilder) {
+		if (logger.isDebugEnabled())
+			flowFunctionCacheBuilder = flowFunctionCacheBuilder.recordStats();
+		this.zeroValue = tabulationProblem.zeroValue();
+		this.icfg = tabulationProblem.interproceduralCFG();
+		FlowFunctions<N, D, SootMethod> flowFunctions = tabulationProblem.autoAddZero()
+				? new ZeroedFlowFunctions<N, D, SootMethod>(tabulationProblem.flowFunctions(), zeroValue)
+				: tabulationProblem.flowFunctions();
+		if (flowFunctionCacheBuilder != null) {
+			ffCache = new FlowFunctionCache<N, D, SootMethod>(flowFunctions, flowFunctionCacheBuilder);
+			flowFunctions = ffCache;
+		} else {
+			ffCache = null;
+		}
+		this.flowFunctions = flowFunctions;
+		this.initialSeeds = tabulationProblem.initialSeeds();
+		this.followReturnsPastSeeds = tabulationProblem.followReturnsPastSeeds();
+		this.numThreads = Math.max(1, tabulationProblem.numThreads());
+		this.executor = getExecutor();
+	}
+
+	/**
+	 * Factory method for creating an instance of the garbage collector
+	 * 
+	 * @return The new garbage collector
+	 */
+	protected IGarbageCollector<N, D> createGarbageCollector() {
+		if (garbageCollector != null)
+			return garbageCollector;
+		// NullGarbageCollector<N, D> gc = new NullGarbageCollector<>();
+		// AggressiveGarbageCollector<N, D> gc = new AggressiveGarbageCollector<>(icfg,
+		// jumpFunctions);
+		abstDependencyGraph = new AbstrationDependencyGraph<>();
+		NormalGarbageCollector<N, D> gc = new NormalGarbageCollector<>(icfg, jumpFunctions, endSummary,
+				abstDependencyGraph);
+		gc.setSleepTimeSeconds(sleepTime);
+		logger.info("sleep time is {}", sleepTime);
+		@SuppressWarnings("unchecked")
+		GCSolverPeerGroup<Pair<SootMethod, D>> gcSolverGroup = (GCSolverPeerGroup<Pair<SootMethod, D>>) solverPeerGroup;
+		gc.setPeerGroup(gcSolverGroup.getGCPeerGroup());
+		return garbageCollector = gc;
+	}
+
+	public void setSolverId(boolean solverId) {
+		this.solverId = solverId;
+	}
+
+	/**
+	 * Runs the solver on the configured problem. This can take some time.
+	 */
+	public void solve() {
+		reset();
+
+		// Make sure that we have an instance of the garbage collector
+		if (this.garbageCollector == null)
+			this.garbageCollector = createGarbageCollector();
+
+		// Notify the listeners that the solver has been started
+		for (IMemoryBoundedSolverStatusNotification listener : notificationListeners)
+			listener.notifySolverStarted(this);
+
+		submitInitialSeeds();
+		awaitCompletionComputeValuesAndShutdown();
+
+		// Notify the listeners that the solver has been terminated
+		for (IMemoryBoundedSolverStatusNotification listener : notificationListeners)
+			listener.notifySolverTerminated(this);
+
+		@SuppressWarnings("unchecked")
+		GCSolverPeerGroup<Pair<SootMethod, D>> gcSolverGroup = (GCSolverPeerGroup<Pair<SootMethod, D>>) solverPeerGroup;
+		gcSolverGroup.getGCPeerGroup().notifySolverTerminated();
+	}
+
+	/**
+	 * Schedules the processing of initial seeds, initiating the analysis. Clients
+	 * should only call this methods if performing synchronization on their own.
+	 * Normally, {@link #solve()} should be called instead.
+	 */
+	protected void submitInitialSeeds() {
+		for (Entry<N, Set<D>> seed : initialSeeds.entrySet()) {
+			N startPoint = seed.getKey();
+			for (D val : seed.getValue())
+				propagate(zeroValue, startPoint, val, null, false, null);
+			addFunction(new PathEdge<N, D>(zeroValue, startPoint, zeroValue));
+		}
+	}
+
+	/**
+	 * Awaits the completion of the exploded super graph. When complete, computes
+	 * result values, shuts down the executor and returns.
+	 */
+	protected void awaitCompletionComputeValuesAndShutdown() {
+		{
+			// run executor and await termination of tasks
+			runExecutorAndAwaitCompletion();
+		}
+		if (logger.isDebugEnabled())
+			printStats();
+
+		// ask executor to shut down;
+		// this will cause new submissions to the executor to be rejected,
+		// but at this point all tasks should have completed anyway
+		executor.shutdown();
+
+		// Wait for the executor to be really gone
+		while (!executor.isTerminated()) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				// silently ignore the exception, it's not an issue if the
+				// thread gets aborted
+			}
+		}
+	}
+
+	/**
+	 * Runs execution, re-throwing exceptions that might be thrown during its
+	 * execution.
+	 */
+	private void runExecutorAndAwaitCompletion() {
+		try {
+			executor.awaitCompletion();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		Throwable exception = executor.getException();
+		if (exception != null) {
+			throw new RuntimeException("There were exceptions during IFDS analysis. Exiting.", exception);
+		}
+	}
+
+	/**
+	 * Dispatch the processing of a given edge. It may be executed in a different
+	 * thread.
+	 * 
+	 * @param newSelfLoop indicate that this path edge is a self-loop edge like <s,
+	 *                    d>--><s, d>.
+	 * @param edge        the edge to process
+	 * @param orgSrc      used for building abstraction dependency graph.
+	 */
+	protected void scheduleEdgeProcessing(boolean newSelfLoop, PathEdge<N, D> edge, Pair<SootMethod, D> orgSrc) {
+		// If the executor has been killed, there is little point
+		// in submitting new tasks
+		if (killFlag != null || executor.isTerminating() || executor.isTerminated())
+			return;
+
+		// this condition is used to avoid the second limitation of CleanDroid.
+		if (newSelfLoop) {
+			SootMethod sm = icfg.getMethodOf(edge.getTarget());
+			Pair<SootMethod, D> abst = new Pair<>(sm, edge.factAtSource());
+			Map<EndSummary<N, D>, EndSummary<N, D>> map = new MyConcurrentHashMap<>();
+			Map<EndSummary<N, D>, EndSummary<N, D>> sumMap = endSummary.putIfAbsentElseGet(abst, map);
+			if (map != sumMap) { // already exists.
+				return;
+			}
+			if (garbageCollector instanceof NormalGarbageCollector && orgSrc != null) {
+				try {
+					abstDependencyGraph.lock();
+					abstDependencyGraph.addEdge(orgSrc, abst);
+				} finally {
+					abstDependencyGraph.unlock();
+				}
+			}
+		}
+		garbageCollector.notifyEdgeSchedule(edge);
+		executor.execute(new PathEdgeProcessingTask(edge, solverId));
+		propagationCount.increment();
+		garbageCollector.gc();
+	}
+
+	/**
+	 * Lines 13-20 of the algorithm; processing a call site in the caller's context.
+	 * 
+	 * For each possible callee, registers incoming call edges. Also propagates
+	 * call-to-return flows and summarized callee flows within the caller.
+	 * 
+	 * @param edge an edge whose target node resembles a method call
+	 */
+	private void processCall(PathEdge<N, D> edge) {
+		final D d1 = edge.factAtSource();
+		final N n = edge.getTarget(); // a call node; line 14...
+		final D d2 = edge.factAtTarget();
+		assert d2 != null;
+		Collection<N> returnSiteNs = icfg.getReturnSitesOfCallAt(n);
+
+		// for each possible callee
+		Collection<SootMethod> callees = icfg.getCalleesOfCallAt(n);
+		if (maxCalleesPerCallSite < 0 || callees.size() <= maxCalleesPerCallSite) {
+			callees.stream().filter(m -> m.isConcrete()).forEach(new Consumer<SootMethod>() {
+
+				@Override
+				public void accept(SootMethod sCalledProcN) {
+					// Early termination check
+					if (killFlag != null)
+						return;
+
+					// compute the call-flow function
+					FlowFunction<D> function = flowFunctions.getCallFlowFunction(n, sCalledProcN);
+					Set<D> res = computeCallFlowFunction(function, d1, d2);
+
+					if (res != null && !res.isEmpty()) {
+						Collection<N> startPointsOf = icfg.getStartPointsOf(sCalledProcN);
+						// for each result node of the call-flow function
+						for (D d3 : res) {
+							if (memoryManager != null)
+								d3 = memoryManager.handleGeneratedMemoryObject(d2, d3);
+							if (d3 == null)
+								continue;
+
+							// register the fact that <sp,d3> has an incoming edge from
+							// <n,d2>
+							// line 15.1 of Naeem/Lhotak/Rodriguez
+							if (!addIncoming(sCalledProcN, d3, n, d1, d2))
+								continue;
+
+							// If we already have a summary, we take that summary instead of propagating
+							// through the callee again
+							if (applyEndSummaryOnCall(d1, n, d2, returnSiteNs, sCalledProcN, d3))
+								continue;
+
+							// for each callee's start point(s)
+							for (N sP : startPointsOf) {
+								// create initial self-loop
+								propagate(d3, sP, d3, n, false, new Pair<>(icfg.getMethodOf(n), d1)); // line 15
+							}
+						}
+					}
+				}
+
+			});
+		}
+
+		// line 17-19 of Naeem/Lhotak/Rodriguez
+		// process intra-procedural flows along call-to-return flow functions
+		for (N returnSiteN : returnSiteNs) {
+			FlowFunction<D> callToReturnFlowFunction = flowFunctions.getCallToReturnFlowFunction(n, returnSiteN);
+			Set<D> res = computeCallToReturnFlowFunction(callToReturnFlowFunction, d1, d2);
+			if (res != null && !res.isEmpty()) {
+				for (D d3 : res) {
+					if (memoryManager != null)
+						d3 = memoryManager.handleGeneratedMemoryObject(d2, d3);
+					if (d3 != null)
+						propagate(d1, returnSiteN, d3, n, false, null);
+				}
+			}
+		}
+	}
+
+	protected boolean applyEndSummaryOnCall(final D d1, final N n, final D d2, Collection<N> returnSiteNs,
+			SootMethod sCalledProcN, D d3) {
+		// line 15.2
+		Set<EndSummary<N, D>> endSumm = endSummary(sCalledProcN, d3);
+
+		// still line 15.2 of Naeem/Lhotak/Rodriguez
+		// for each already-queried exit value <eP,d4> reachable
+		// from <sP,d3>, create new caller-side jump functions to
+		// the return sites because we have observed a potentially
+		// new incoming edge into <sP,d3>
+		if (endSumm != null && !endSumm.isEmpty()) {
+			for (EndSummary<N, D> entry : endSumm) {
+				N eP = entry.eP;
+				D d4 = entry.d4;
+
+				// We must acknowledge the incoming abstraction from the other path
+				entry.calleeD1.addNeighbor(d3);
+				// for each return site
+				for (N retSiteN : returnSiteNs) {
+					// compute return-flow function
+					FlowFunction<D> retFunction = flowFunctions.getReturnFlowFunction(n, sCalledProcN, eP, retSiteN);
+					Set<D> retFlowRes = computeReturnFlowFunction(retFunction, d3, d4, n, Collections.singleton(d1));
+					if (retFlowRes != null && !retFlowRes.isEmpty()) {
+						// for each target value of the function
+						for (D d5 : retFlowRes) {
+							if (memoryManager != null)
+								d5 = memoryManager.handleGeneratedMemoryObject(d4, d5);
+
+							// If we have not changed anything in
+							// the callee, we do not need the facts from
+							// there. Even if we change something:
+							// If we don't need the concrete path,
+							// we can skip the callee in the predecessor
+							// chain
+							D d5p = shortenPredecessors(d5, d2, d3, eP, n);
+							propagate(d1, retSiteN, d5p, n, false, null);
+						}
+					}
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Computes the call flow function for the given call-site abstraction
+	 * 
+	 * @param callFlowFunction The call flow function to compute
+	 * @param d1               The abstraction at the current method's start node.
+	 * @param d2               The abstraction at the call site
+	 * @return The set of caller-side abstractions at the callee's start node
+	 */
+	protected Set<D> computeCallFlowFunction(FlowFunction<D> callFlowFunction, D d1, D d2) {
+		return callFlowFunction.computeTargets(d2);
+	}
+
+	/**
+	 * Computes the call-to-return flow function for the given call-site abstraction
+	 * 
+	 * @param callToReturnFlowFunction The call-to-return flow function to compute
+	 * @param d1                       The abstraction at the current method's start
+	 *                                 node.
+	 * @param d2                       The abstraction at the call site
+	 * @return The set of caller-side abstractions at the return site
+	 */
+	protected Set<D> computeCallToReturnFlowFunction(FlowFunction<D> callToReturnFlowFunction, D d1, D d2) {
+		return callToReturnFlowFunction.computeTargets(d2);
+	}
+
+	/**
+	 * Lines 21-32 of the algorithm.
+	 * 
+	 * Stores callee-side summaries. Also, at the side of the caller, propagates
+	 * intra-procedural flows to return sites using those newly computed summaries.
+	 * 
+	 * @param edge an edge whose target node resembles a method exits
+	 */
+	protected void processExit(PathEdge<N, D> edge) {
+		final N n = edge.getTarget(); // an exit node; line 21...
+		SootMethod methodThatNeedsSummary = icfg.getMethodOf(n);
+
+		final D d1 = edge.factAtSource();
+		final D d2 = edge.factAtTarget();
+
+		// for each of the method's start points, determine incoming calls
+
+		// line 21.1 of Naeem/Lhotak/Rodriguez
+		// register end-summary
+		if (!addEndSummary(methodThatNeedsSummary, d1, n, d2))
+			return;
+		Set<IncomingRecord<N, D>> inc = incoming(d1, methodThatNeedsSummary);
+
+		// for each incoming call edge already processed
+		// (see processCall(..))
+		if (inc != null && !inc.isEmpty()) {
+			for (IncomingRecord<N, D> entry : inc) {
+				// Early termination check
+				if (killFlag != null)
+					return;
+
+				// line 22
+				N c = entry.n;
+				Set<D> callerSideDs = Collections.singleton(entry.d1);
+				// for each return site
+				for (N retSiteC : icfg.getReturnSitesOfCallAt(c)) {
+					// compute return-flow function
+					FlowFunction<D> retFunction = flowFunctions.getReturnFlowFunction(c, methodThatNeedsSummary, n,
+							retSiteC);
+					Set<D> targets = computeReturnFlowFunction(retFunction, d1, d2, c, callerSideDs);
+					// for each incoming-call value
+					if (targets != null && !targets.isEmpty()) {
+						final D d4 = entry.d1;
+						final D predVal = entry.d2;
+
+						for (D d5 : targets) {
+							if (memoryManager != null)
+								d5 = memoryManager.handleGeneratedMemoryObject(d2, d5);
+							if (d5 == null)
+								continue;
+
+							// If we have not changed anything in the callee, we do not need the facts from
+							// there. Even if we change something: If we don't need the concrete path, we
+							// can skip the callee in the predecessor chain
+							D d5p = shortenPredecessors(d5, predVal, d1, n, c);
+							propagate(d4, retSiteC, d5p, c, false, null);
+
+							// Make sure all of the incoming edges are registered with the edge from the new
+							// summary
+							d1.addNeighbor(entry.d3);
+						}
+					}
+				}
+			}
+		}
+
+		// handling for unbalanced problems where we return out of a method with
+		// a fact for which we have no incoming flow
+		// note: we propagate that way only values that originate from ZERO, as
+		// conditionally generated values should only be propagated into callers that
+		// have an incoming edge for this condition
+		if (followReturnsPastSeeds && d1 == zeroValue && (inc == null || inc.isEmpty())) {
+			Collection<N> callers = icfg.getCallersOf(methodThatNeedsSummary);
+			for (N c : callers) {
+				for (N retSiteC : icfg.getReturnSitesOfCallAt(c)) {
+					FlowFunction<D> retFunction = flowFunctions.getReturnFlowFunction(c, methodThatNeedsSummary, n,
+							retSiteC);
+					Set<D> targets = computeReturnFlowFunction(retFunction, d1, d2, c,
+							Collections.singleton(zeroValue));
+					if (targets != null && !targets.isEmpty()) {
+						for (D d5 : targets) {
+							if (memoryManager != null)
+								d5 = memoryManager.handleGeneratedMemoryObject(d2, d5);
+							if (d5 != null)
+								propagate(zeroValue, retSiteC, d5, c, true, null);
+						}
+					}
+				}
+			}
+			// in cases where there are no callers, the return statement would
+			// normally not be processed at all; this might be undesirable if the flow
+			// function has a side effect such as registering a taint; instead we thus call
+			// the return flow function will a null caller
+			if (callers.isEmpty()) {
+				FlowFunction<D> retFunction = flowFunctions.getReturnFlowFunction(null, methodThatNeedsSummary, n,
+						null);
+				retFunction.computeTargets(d2);
+			}
+		}
+	}
+
+	/**
+	 * Computes the return flow function for the given set of caller-side
+	 * abstractions.
+	 * 
+	 * @param retFunction  The return flow function to compute
+	 * @param d1           The abstraction at the beginning of the callee
+	 * @param d2           The abstraction at the exit node in the callee
+	 * @param callSite     The call site
+	 * @param callerSideDs The abstractions at the call site
+	 * @return The set of caller-side abstractions at the return site
+	 */
+	protected Set<D> computeReturnFlowFunction(FlowFunction<D> retFunction, D d1, D d2, N callSite,
+			Collection<D> callerSideDs) {
+		return retFunction.computeTargets(d2);
+	}
+
+	/**
+	 * Lines 33-37 of the algorithm. Simply propagate normal, intra-procedural
+	 * flows.
+	 * 
+	 * @param edge
+	 */
+	private void processNormalFlow(PathEdge<N, D> edge) {
+		final D d1 = edge.factAtSource();
+		final N n = edge.getTarget();
+		final D d2 = edge.factAtTarget();
+
+		for (N m : icfg.getSuccsOf(n)) {
+			// Early termination check
+			if (killFlag != null)
+				return;
+
+			// Compute the flow function
+			FlowFunction<D> flowFunction = flowFunctions.getNormalFlowFunction(n, m);
+			Set<D> res = computeNormalFlowFunction(flowFunction, d1, d2);
+			if (res != null && !res.isEmpty()) {
+				for (D d3 : res) {
+					if (memoryManager != null && d2 != d3)
+						d3 = memoryManager.handleGeneratedMemoryObject(d2, d3);
+					if (d3 != null)
+						propagate(d1, m, d3, null, false, null);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Computes the normal flow function for the given set of start and end
+	 * abstractions.
+	 * 
+	 * @param flowFunction The normal flow function to compute
+	 * @param d1           The abstraction at the method's start node
+	 * @param d2           The abstraction at the current node
+	 * @return The set of abstractions at the successor node
+	 */
+	protected Set<D> computeNormalFlowFunction(FlowFunction<D> flowFunction, D d1, D d2) {
+		return flowFunction.computeTargets(d2);
+	}
+
+	/**
+	 * Propagates the flow further down the exploded super graph.
+	 * 
+	 * @param sourceVal          the source value of the propagated summary edge
+	 * @param target             the target statement
+	 * @param targetVal          the target value at the target statement
+	 * @param relatedCallSite    for call and return flows the related call
+	 *                           statement, <code>null</code> otherwise (this value
+	 *                           is not used within this implementation but may be
+	 *                           useful for subclasses of
+	 *                           {@link soot.jimple.infoflow.solver.gcSolver.IFDSSolver})
+	 * @param isUnbalancedReturn <code>true</code> if this edge is propagating an
+	 *                           unbalanced return (this value is not used within
+	 *                           this implementation but may be useful for
+	 *                           subclasses of
+	 *                           {@link soot.jimple.infoflow.solver.gcSolver.IFDSSolver})
+	 * @param orgSrc             extended for building abstraction dependency graph.
+	 */
+	protected void propagate(D sourceVal, N target, D targetVal,
+			/* deliberately exposed to clients */ N relatedCallSite,
+			/* deliberately exposed to clients */ boolean isUnbalancedReturn,
+			Pair<SootMethod, D> orgSrc) {
+		// Let the memory manager run
+		if (memoryManager != null) {
+			sourceVal = memoryManager.handleMemoryObject(sourceVal);
+			targetVal = memoryManager.handleMemoryObject(targetVal);
+			if (targetVal == null)
+				return;
+		}
+
+		// Check the path length
+		if (maxAbstractionPathLength >= 0 && targetVal.getPathLength() > maxAbstractionPathLength)
+			return;
+
+		final PathEdge<N, D> edge = new PathEdge<>(sourceVal, target, targetVal);
+		final D existingVal = addFunction(edge);
+		if (existingVal != null) {
+			if (existingVal != targetVal) {
+				// Check whether we need to retain this abstraction
+				boolean isEssential;
+				if (memoryManager == null)
+					isEssential = relatedCallSite != null && icfg.isCallStmt(relatedCallSite);
+				else
+					isEssential = memoryManager.isEssentialJoinPoint(targetVal, relatedCallSite);
+
+				if (maxJoinPointAbstractions < 0 || existingVal.getNeighborCount() < maxJoinPointAbstractions
+						|| isEssential) {
+					existingVal.addNeighbor(targetVal);
+				}
+			}
+		} else {
+			boolean isSelfLoopEdge = sourceVal == targetVal && icfg.isStartPoint(target);
+			scheduleEdgeProcessing(isSelfLoopEdge, edge, orgSrc);
+		}
+	}
+
+	/**
+	 * Records a jump function. The source statement is implicit.
+	 * 
+	 * @see PathEdge
+	 */
+	public D addFunction(PathEdge<N, D> edge) {
+		SootMethod method = icfg.getMethodOf(edge.getTarget());
+		PathEdge<N, D> oldEdge = jumpFunctions.putIfAbsent(new Pair<>(method, edge.factAtSource()), edge);
+		return oldEdge == null ? null : oldEdge.factAtTarget();
+	}
+
+	protected Set<EndSummary<N, D>> endSummary(SootMethod m, D d3) {
+		Map<EndSummary<N, D>, EndSummary<N, D>> map = endSummary.get(new Pair<>(m, d3));
+		return map == null ? null : map.keySet();
+	}
+
+	private boolean addEndSummary(SootMethod m, D d1, N eP, D d2) {
+		if (d1 == zeroValue)
+			return true;
+
+		Map<EndSummary<N, D>, EndSummary<N, D>> summaries = endSummary.putIfAbsentElseGet(new Pair<>(m, d1),
+				() -> new ConcurrentHashMap<>());
+		EndSummary<N, D> newSummary = new EndSummary<>(eP, d2, d1);
+		EndSummary<N, D> existingSummary = summaries.putIfAbsent(newSummary, newSummary);
+		if (existingSummary != null) {
+			existingSummary.calleeD1.addNeighbor(d2);
+			return false;
+		}
+		return true;
+	}
+
+	protected static class IncomingRecord<N, D extends FastSolverLinkedNode<D, N>> {
+
+		public final N n;
+		public final D d1;
+		public final D d2;
+		public final D d3;
+
+		public IncomingRecord(N n, D d1, D d2, D d3) {
+			this.n = n;
+			this.d1 = d1;
+			this.d2 = d2;
+			this.d3 = d3;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((d1 == null) ? 0 : d1.hashCode());
+			result = prime * result + ((d2 == null) ? 0 : d2.hashCode());
+			result = prime * result + ((d3 == null) ? 0 : d3.hashCode());
+			result = prime * result + ((n == null) ? 0 : n.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			IncomingRecord other = (IncomingRecord) obj;
+			if (d1 == null) {
+				if (other.d1 != null)
+					return false;
+			} else if (!d1.equals(other.d1))
+				return false;
+			if (d2 == null) {
+				if (other.d2 != null)
+					return false;
+			} else if (!d2.equals(other.d2))
+				return false;
+			if (d3 == null) {
+				if (other.d3 != null)
+					return false;
+			} else if (!d3.equals(other.d3))
+				return false;
+			if (n == null) {
+				if (other.n != null)
+					return false;
+			} else if (!n.equals(other.n))
+				return false;
+			return true;
+		}
+
+	}
+
+	protected Set<IncomingRecord<N, D>> incoming(D d1, SootMethod m) {
+		Set<IncomingRecord<N, D>> inc = incoming.get(new Pair<SootMethod, D>(m, d1));
+		return inc;
+	}
+
+	protected boolean addIncoming(SootMethod m, D d3, N n, D d1, D d2) {
+		IncomingRecord<N, D> newRecord = new IncomingRecord<N, D>(n, d1, d2, d3);
+		IncomingRecord<N, D> rec = incoming.putIfAbsent(new Pair<SootMethod, D>(m, d3), newRecord);
+		return rec == null;
+	}
+
+	/**
+	 * Factory method for this solver's thread-pool executor.
+	 */
+	protected InterruptableExecutor getExecutor() {
+		SetPoolExecutor executor = new SetPoolExecutor(1, this.numThreads, 30, TimeUnit.SECONDS,
+				new LinkedBlockingQueue<Runnable>());
+		executor.setThreadFactory(new ThreadFactory() {
+
+			@Override
+			public Thread newThread(Runnable r) {
+				Thread thrIFDS = new Thread(r);
+				thrIFDS.setDaemon(true);
+				thrIFDS.setName("IFDS Solver");
+				return thrIFDS;
+			}
+		});
+		return executor;
+	}
+
+	/**
+	 * Returns a String used to identify the output of this solver in debug mode.
+	 * Subclasses can overwrite this string to distinguish the output from different
+	 * solvers.
+	 */
+	protected String getDebugName() {
+		return "FAST IFDS SOLVER";
+	}
+
+	public void printStats() {
+		if (logger.isDebugEnabled()) {
+			if (ffCache != null)
+				ffCache.printStats();
+		} else {
+			logger.info("No statistics were collected, as DEBUG is disabled.");
+		}
+	}
+
+	private class PathEdgeProcessingTask implements Runnable {
+
+		private final PathEdge<N, D> edge;
+		private final boolean solverId;
+
+		public PathEdgeProcessingTask(PathEdge<N, D> edge, boolean solverId) {
+			this.edge = edge;
+			this.solverId = solverId;
+		}
+
+		public void run() {
+			if (icfg.isCallStmt(edge.getTarget())) {
+				processCall(edge);
+			} else {
+				// note that some statements, such as "throw" may be
+				// both an exit statement and a "normal" statement
+				if (icfg.isExitStmt(edge.getTarget()))
+					processExit(edge);
+				if (!icfg.getSuccsOf(edge.getTarget()).isEmpty())
+					processNormalFlow(edge);
+			}
+			garbageCollector.notifyTaskProcessed(edge);
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((edge == null) ? 0 : edge.hashCode());
+			result = prime * result + (solverId ? 1231 : 1237);
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			PathEdgeProcessingTask other = (PathEdgeProcessingTask) obj;
+			if (edge == null) {
+				if (other.edge != null)
+					return false;
+			} else if (!edge.equals(other.edge))
+				return false;
+			if (solverId != other.solverId)
+				return false;
+			return true;
+		}
+
+	}
+
+	/**
+	 * Sets the maximum number of abstractions that shall be recorded per join
+	 * point. In other words, enabling this option disables the recording of
+	 * neighbors beyond the given count.
+	 * 
+	 * @param maxJoinPointAbstractions The maximum number of abstractions per join
+	 *                                 point, or -1 to record an arbitrary number of
+	 *                                 join point abstractions
+	 */
+	public void setMaxJoinPointAbstractions(int maxJoinPointAbstractions) {
+		this.maxJoinPointAbstractions = maxJoinPointAbstractions;
+	}
+
+	/**
+	 * Sets the memory manager that shall be used to manage the abstractions
+	 * 
+	 * @param memoryManager The memory manager that shall be used to manage the
+	 *                      abstractions
+	 */
+	public void setMemoryManager(IMemoryManager<D, N> memoryManager) {
+		this.memoryManager = memoryManager;
+	}
+
+	/**
+	 * Gets the memory manager used by this solver to reduce memory consumption
+	 * 
+	 * @return The memory manager registered with this solver
+	 */
+	public IMemoryManager<D, N> getMemoryManager() {
+		return this.memoryManager;
+	}
+
+	@Override
+	public void forceTerminate(ISolverTerminationReason reason) {
+		this.killFlag = reason;
+		this.executor.interrupt();
+		this.executor.shutdown();
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return killFlag != null || this.executor.isFinished();
+	}
+
+	@Override
+	public boolean isKilled() {
+		return killFlag != null;
+	}
+
+	@Override
+	public void reset() {
+		this.killFlag = null;
+	}
+
+	@Override
+	public void addStatusListener(IMemoryBoundedSolverStatusNotification listener) {
+		this.notificationListeners.add(listener);
+	}
+
+	@Override
+	public ISolverTerminationReason getTerminationReason() {
+		return killFlag;
+	}
+
+	public void setMaxCalleesPerCallSite(int maxCalleesPerCallSite) {
+		this.maxCalleesPerCallSite = maxCalleesPerCallSite;
+	}
+
+	public void setMaxAbstractionPathLength(int maxAbstractionPathLength) {
+		this.maxAbstractionPathLength = maxAbstractionPathLength;
+	}
+
+	/**
+	 * Sets the peer group in which this solver operates. Peer groups allow for
+	 * synchronization between solvers
+	 * 
+	 * @param solverPeerGroup The solver peer group
+	 */
+	public void setPeerGroup(SolverPeerGroup solverPeerGroup) {
+		this.solverPeerGroup = solverPeerGroup;
+	}
+
+	/**
+	 * Notifies the solver that no further edges will be scheduled
+	 */
+	public void terminate() {
+	}
+
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/IGraph.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/IGraph.java
@@ -1,0 +1,25 @@
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import java.util.Set;
+
+public interface IGraph<N> {
+
+	public Set<N> getNodes();
+
+	public Set<N> succsOf(N n);
+
+	public Set<N> predsOf(N n);
+
+	public void addNode(N n);
+
+	public void addEdge(N n1, N n2);
+
+	public boolean contains(N n);
+
+	/*
+	 * removing the node itself and all edges it associated with.
+	 */
+	public void remove(N n);
+
+	public void removeEdge(N n1, N n2);
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/InfoflowSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/InfoflowSolver.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Secure Software Engineering Group at EC SPRIDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v2.1
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * 
+ * Contributors: Christian Fritz, Steven Arzt, Siegfried Rasthofer, Eric
+ * Bodden, and others.
+ ******************************************************************************/
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import java.util.Collection;
+import java.util.Set;
+
+import heros.FlowFunction;
+import heros.solver.PathEdge;
+import soot.SootMethod;
+import soot.Unit;
+import soot.jimple.infoflow.data.Abstraction;
+import soot.jimple.infoflow.problems.AbstractInfoflowProblem;
+import soot.jimple.infoflow.solver.EndSummary;
+import soot.jimple.infoflow.solver.IFollowReturnsPastSeedsHandler;
+import soot.jimple.infoflow.solver.IInfoflowSolver;
+import soot.jimple.infoflow.solver.executors.InterruptableExecutor;
+import soot.jimple.infoflow.solver.functions.SolverCallFlowFunction;
+import soot.jimple.infoflow.solver.functions.SolverCallToReturnFlowFunction;
+import soot.jimple.infoflow.solver.functions.SolverNormalFlowFunction;
+import soot.jimple.infoflow.solver.functions.SolverReturnFlowFunction;
+import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
+import soot.util.ConcurrentHashMultiMap;
+
+/**
+ * We are subclassing the JimpleIFDSSolver because we need the same executor for
+ * both the forward and the backward analysis Also we need to be able to insert
+ * edges containing new taint information
+ * 
+ */
+public class InfoflowSolver extends IFDSSolver<Unit, Abstraction, BiDiInterproceduralCFG<Unit, SootMethod>>
+		implements IInfoflowSolver {
+
+	private IFollowReturnsPastSeedsHandler followReturnsPastSeedsHandler = null;
+	private final AbstractInfoflowProblem problem;
+
+	public InfoflowSolver(AbstractInfoflowProblem problem, InterruptableExecutor executor, int sleepTime) {
+		super(problem, sleepTime);
+		this.problem = problem;
+		this.executor = executor;
+		problem.setSolver(this);
+	}
+
+	@Override
+	protected InterruptableExecutor getExecutor() {
+		return executor;
+	}
+
+	@Override
+	public boolean processEdge(PathEdge<Unit, Abstraction> edge) {
+		// We might not have a garbage collector yet
+		if (this.garbageCollector == null) {
+			synchronized (this) {
+				if (this.garbageCollector == null)
+					this.garbageCollector = createGarbageCollector();
+			}
+		}
+
+		propagate(edge.factAtSource(), edge.getTarget(), edge.factAtTarget(), null, false, null);
+		return true;
+	}
+
+	@Override
+	public void injectContext(IInfoflowSolver otherSolver, SootMethod callee, Abstraction d3, Unit callSite,
+			Abstraction d2, Abstraction d1) {
+		if (!addIncoming(callee, d3, callSite, d1, d2))
+			return;
+
+		Collection<Unit> returnSiteNs = icfg.getReturnSitesOfCallAt(callSite);
+		applyEndSummaryOnCall(d1, callSite, d2, returnSiteNs, callee, d3);
+	}
+
+	@Override
+	protected Set<Abstraction> computeReturnFlowFunction(FlowFunction<Abstraction> retFunction, Abstraction d1,
+			Abstraction d2, Unit callSite, Collection<Abstraction> callerSideDs) {
+		if (retFunction instanceof SolverReturnFlowFunction) {
+			// Get the d1s at the start points of the caller
+			return ((SolverReturnFlowFunction) retFunction).computeTargets(d2, d1, callerSideDs);
+		} else
+			return retFunction.computeTargets(d2);
+	}
+
+	@Override
+	protected Set<Abstraction> computeNormalFlowFunction(FlowFunction<Abstraction> flowFunction, Abstraction d1,
+			Abstraction d2) {
+		if (flowFunction instanceof SolverNormalFlowFunction)
+			return ((SolverNormalFlowFunction) flowFunction).computeTargets(d1, d2);
+		else
+			return flowFunction.computeTargets(d2);
+	}
+
+	@Override
+	protected Set<Abstraction> computeCallToReturnFlowFunction(FlowFunction<Abstraction> flowFunction, Abstraction d1,
+			Abstraction d2) {
+		if (flowFunction instanceof SolverCallToReturnFlowFunction)
+			return ((SolverCallToReturnFlowFunction) flowFunction).computeTargets(d1, d2);
+		else
+			return flowFunction.computeTargets(d2);
+	}
+
+	@Override
+	protected Set<Abstraction> computeCallFlowFunction(FlowFunction<Abstraction> flowFunction, Abstraction d1,
+			Abstraction d2) {
+		if (flowFunction instanceof SolverCallFlowFunction)
+			return ((SolverCallFlowFunction) flowFunction).computeTargets(d1, d2);
+		else
+			return flowFunction.computeTargets(d2);
+	}
+
+	@Override
+	public void cleanup() {
+		this.jumpFunctions = new ConcurrentHashMultiMap<>();
+		this.incoming.clear();
+		this.endSummary.clear();
+		if (this.ffCache != null)
+			this.ffCache.invalidate();
+	}
+
+	@Override
+	public Set<EndSummary<Unit, Abstraction>> endSummary(SootMethod m, Abstraction d3) {
+		return super.endSummary(m, d3);
+	}
+
+	@Override
+	protected void processExit(PathEdge<Unit, Abstraction> edge) {
+		super.processExit(edge);
+
+		if (followReturnsPastSeeds && followReturnsPastSeedsHandler != null) {
+			final Abstraction d1 = edge.factAtSource();
+			final Unit u = edge.getTarget();
+			final Abstraction d2 = edge.factAtTarget();
+
+			final SootMethod methodThatNeedsSummary = icfg.getMethodOf(u);
+			final Set<IncomingRecord<Unit, Abstraction>> inc = incoming(d1, methodThatNeedsSummary);
+
+			if (inc == null || inc.isEmpty())
+				followReturnsPastSeedsHandler.handleFollowReturnsPastSeeds(d1, u, d2);
+		}
+	}
+
+	@Override
+	public void setFollowReturnsPastSeedsHandler(IFollowReturnsPastSeedsHandler handler) {
+		this.followReturnsPastSeedsHandler = handler;
+	}
+
+	@Override
+	public long getPropagationCount() {
+		return propagationCount.sum();
+	}
+
+	@Override
+	public AbstractInfoflowProblem getTabulationProblem() {
+		return problem;
+	}
+
+}

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/NormalGarbageCollector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/fpc/NormalGarbageCollector.java
@@ -1,0 +1,90 @@
+package soot.jimple.infoflow.solver.gcSolver.fpc;
+
+import heros.solver.Pair;
+import heros.solver.PathEdge;
+import soot.SootMethod;
+import soot.jimple.infoflow.collect.MyConcurrentHashMap;
+import soot.jimple.infoflow.solver.EndSummary;
+import soot.jimple.infoflow.solver.cfg.BackwardsInfoflowCFG;
+import soot.jimple.infoflow.solver.fastSolver.FastSolverLinkedNode;
+import soot.jimple.infoflow.solver.gcSolver.IGCReferenceProvider;
+import soot.jimple.toolkits.ide.icfg.BiDiInterproceduralCFG;
+import soot.util.ConcurrentHashMultiMap;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NormalGarbageCollector<N, D extends FastSolverLinkedNode<D, N>>
+		extends FineGrainedReferenceCountingGarbageCollector<N, D> {
+
+	protected static final Logger logger = LoggerFactory.getLogger(NormalGarbageCollector.class);
+	protected final AbstrationDependencyGraph<D> abstDependencyGraph;
+	protected final MyConcurrentHashMap<Pair<SootMethod, D>, Map<EndSummary<N, D>, EndSummary<N, D>>> endSummary;
+
+	public NormalGarbageCollector(BiDiInterproceduralCFG<N, SootMethod> icfg,
+			ConcurrentHashMultiMap<Pair<SootMethod, D>, PathEdge<N, D>> jumpFunctions,
+			MyConcurrentHashMap<Pair<SootMethod, D>, Map<EndSummary<N, D>, EndSummary<N, D>>> endSummary,
+			AbstrationDependencyGraph<D> adg) {
+		super(icfg, jumpFunctions, null);
+		this.abstDependencyGraph = adg;
+		this.endSummary = endSummary;
+	}
+
+	@Override
+	public boolean hasActiveDependencies(Pair<SootMethod, D> abstraction) {
+		int changeCounter = -1;
+		try {
+			abstDependencyGraph.lock();
+			do {
+				// Update the change counter for the next round
+				changeCounter = jumpFnCounter.getChangeCounter();
+
+				// Check the method itself
+				if (jumpFnCounter.get(abstraction) > 0)
+					return true;
+
+				// Check the transitive callees
+				Set<Pair<SootMethod, D>> references = abstDependencyGraph.reachableClosure(abstraction);
+				for (Pair<SootMethod, D> ref : references) {
+					if (jumpFnCounter.get(ref) > 0)
+						return true;
+				}
+			} while (checkChangeCounter && changeCounter != jumpFnCounter.getChangeCounter());
+			// we actually can remove these nodes.
+			// Set<Pair<SootMethod, D>> references =
+			// abstDependencyGraph.reachableClosure(abstraction);
+			// for (Pair<SootMethod, D> ref : references) {
+			// abstDependencyGraph.remove(ref);
+			// }
+		} finally {
+			abstDependencyGraph.unlock();
+		}
+		return false;
+	}
+
+	@Override
+	protected IGCReferenceProvider<Pair<SootMethod, D>> createReferenceProvider() {
+		return null;
+	}
+
+	@Override
+	public void notifySolverTerminated() {
+		super.notifySolverTerminated();
+		String s = "forward";
+		if (icfg instanceof BackwardsInfoflowCFG) {
+			s = "backward";
+		}
+		logger.info(icfg.getClass().toString());
+		logger.info(String.format("#nodes of %s Abstraction Dependency Graph: %d", s, abstDependencyGraph.nodeSize()));
+		logger.info(String.format("#edges of %s Abstraction Dependency Graph: %d", s, abstDependencyGraph.edgeSize()));
+		logger.info(String.format("#dummy end summary edges of %s: %d", s, this.endSummary.keySet().size()));
+		long v = 0;
+		for(Map<EndSummary<N, D>, EndSummary<N, D>> map: this.endSummary.values()) {
+			v += map.size();
+		}
+		logger.info(String.format("#end summary edges of %s: %d", s, v));
+	}
+}


### PR DESCRIPTION
In this pull request, we refactored CleanDroid to support other garbage-collecting solvers, and then add the implementation of FPC, the fine-grained garbage collector. The main changes are: 
  - add command line options for specifying the number of threads (`-mt`), and the sleep time of garbage collectors (`-st`).
  - refactor the CleanDroid to be generic regarding the granularity of path-edge collection, e.g., at the method or the data-fact level.
  - add the implementation of FPC, the fine-grained garbage collector (`-ds FPC`). Please refer to our [ISSTA'23 paper](https://dongjiehe.github.io/mypaper/ISSTA2023_FPC_Final.pdf) for more details. 