### PR TITLE
StubDroid: Set java.lang.Object as superclass unless specified otherwise

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,17 +19,17 @@ issue that prevents you from doing so. In that case, please let us know (see con
         <dependency>
             <groupId>de.fraunhofer.sit.sse.flowdroid</groupId>
             <artifactId>soot-infoflow</artifactId>
-            <version>2.10.0</version>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.sit.sse.flowdroid</groupId>
             <artifactId>soot-infoflow-summaries</artifactId>
-            <version>2.10.0</version>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.sit.sse.flowdroid</groupId>
             <artifactId>soot-infoflow-android</artifactId>
-            <version>2.10.0</version>
+            <version>2.12.0</version>
         </dependency>
     </dependencies>
 ```
@@ -48,31 +48,21 @@ all you need is the "soot-infoflow-cmd-jar-with-dependencies.jar" file.
 
 ### Building The Tool With Maven
 
-From version 2.5 on, FlowDroid is built using Maven. Use
+Requirements:
+* JDK 11 or above
+* Maven
+* The current snapshot of <a href="https://github.com/soot-oss/soot">Soot</a> installed
 
-```
-EXPORT ANDROID_JARS=<Android JAR folder>
-EXPORT DROIDBENCH=<DroidBench folder>
-mvn install
-```
-
-to build the tool and run all unit tests. The Android JAR folder is the "platforms" directory inside your Android SDK installation
-folder. The DroidBench folder is the location of DroidBench, our micro-benchmark suite. These two environment variables are only
-required for running the unit tests.
-
-If you do not want DroidBench, or are in a hurry and just want to build the tool without the tests (they can take
-quite some time to complete, we have more than 400 of them), try
-
-```
-mvn -DskipTests install
+At the first time, FlowDroid needs to be built from the parent module, i.e. the project's root folder. The full test
+suite takes around 30 minutes, so we recommend to disable the tests when building:
+```shell
+mvn install -DskipTests
 ```
 
-Either way, you will find the built JAR files in the "target" folder of the respective modules. Maven should take care of all
-dependencies that are required for the build. Unless you need to build FlowDroid on a machine without an Internet connection,
-thing should be pretty easy.
-
-Note that our tests runs on Java 8. The tests have not been adapted to newer versions of the JDK yet, so if your system uses
-a newer version, we recommend that you disable the tests for now.
+To run the build with tests enabled, some additional steps are needed:
+* The JDK 8 must be installed at the default location (alternatively, place the `rt.jar` inside `$JAVA_HOME/lib/`)
+* The DroidBench submodule must be initialized (clone with `--recursive`)
+* `ANDROID_JARS` environment variable must be set to the android platforms directory (typically `$HOME/Android/Sdk/platforms/`)
 
 ### Building The Tool With Eclipse
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>

--- a/soot-infoflow-android/pom.xml
+++ b/soot-infoflow-android/pom.xml
@@ -13,13 +13,6 @@
 		<version>2.13.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
-
-	<repositories>
-		<repository>
-			<id>Eclipse</id>
-			<url>https://ssebuild.sit.fraunhofer.de/nexus/repository/maven-mixed/</url>
-		</repository>
-	</repositories>
 	
 	<build>
 		<finalName>soot-infoflow-android-classes</finalName>

--- a/soot-infoflow/pom.xml
+++ b/soot-infoflow/pom.xml
@@ -102,16 +102,6 @@
 			</resource>
 		</resources>
 	</build>
-	
-	<repositories>
-        <repository>
-            <id>Soot-Snapshots</id>
-            <url>https://ssebuild.sit.fraunhofer.de/nexus/repository/Soot/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-	</repositories>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
For context: if Soot does not even have stubs of the super class, it will resolve the class with `superclass==null`. This can happen because the Android hierarchy changed over time and our summaries typically reference the newer version while the used android.jar is older. The hierarchy is automatically fixed due to the hierarchy information in the newer summaries.