### PR TITLE
Always keep neighbors

### DIFF
--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/generator/SummaryGenerator.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/generator/SummaryGenerator.java
@@ -752,7 +752,6 @@ public class SummaryGenerator {
 		// Disable the default path reconstruction. However, still make sure to
 		// retain the contents of the callees.
 		ISummaryInfoflow iFlow = getInfoflowInstance();
-		InfoflowConfiguration.setMergeNeighbors(true);
 		iFlow.setConfig(config);
 
 		if (nativeCallHandler == null)

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/generator/SummaryGeneratorConfiguration.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/generator/SummaryGeneratorConfiguration.java
@@ -40,10 +40,6 @@ public class SummaryGeneratorConfiguration extends InfoflowConfiguration {
 	protected long classSummaryTimeout = -1;
 	private int repeatCount = 1;
 
-	static {
-		SummaryGeneratorConfiguration.setMergeNeighbors(true);
-	}
-
 	/**
 	 * Creates a new instance of the SummaryGeneratorConfiguration class and
 	 * initializes it with the default configuration options

--- a/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/InfoflowConfiguration.java
@@ -1337,8 +1337,6 @@ public class InfoflowConfiguration {
 
 	private boolean pathAgnosticResults = true;
 	private static boolean oneResultPerAccessPath = false;
-	private static boolean mergeNeighbors = false;
-
 	private int stopAfterFirstKFlows = 0;
 	private ImplicitFlowMode implicitFlowMode = ImplicitFlowMode.NoImplicitFlows;
 	private boolean enableExceptions = true;
@@ -1472,26 +1470,6 @@ public class InfoflowConfiguration {
 	 */
 	public static void setOneResultPerAccessPath(boolean oneResultPerAP) {
 		oneResultPerAccessPath = oneResultPerAP;
-	}
-
-	/**
-	 * Gets whether neighbors at the same statement shall be merged into a single
-	 * abstraction
-	 * 
-	 * @return True if equivalent neighbor shall be merged, otherwise false
-	 */
-	public static boolean getMergeNeighbors() {
-		return mergeNeighbors;
-	}
-
-	/**
-	 * Sets whether neighbors at the same statement shall be merged into a single
-	 * abstraction
-	 * 
-	 * @param value True if equivalent neighbor shall be merged, otherwise false
-	 */
-	public static void setMergeNeighbors(boolean value) {
-		InfoflowConfiguration.mergeNeighbors = value;
 	}
 
 	/**

--- a/soot-infoflow/test/soot/jimple/infoflow/test/OtherTestCode.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/OtherTestCode.java
@@ -13,6 +13,7 @@ package soot.jimple.infoflow.test;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.LinkedList;
+import java.util.Random;
 
 import soot.jimple.infoflow.test.android.AccountManager;
 import soot.jimple.infoflow.test.android.ConnectionManager;
@@ -649,7 +650,6 @@ public class OtherTestCode {
 		cm.publish(a.field1);
 	}
 
-
 	int source1() {
 		return TelephonyManager.getIMEI();
 	}
@@ -685,4 +685,25 @@ public class OtherTestCode {
 		cm.publish(add42(i));
 	}
 
+	int source3() {
+		return TelephonyManager.getIMEI();
+	}
+
+	public void testNeighbors1() {
+		ConnectionManager cm = new ConnectionManager();
+		int i;
+		if (new Random().nextBoolean()) {
+			i = source1();
+			i = add42(i);
+		} else if (new Random().nextBoolean()) {
+			i = source2();
+			i = add42(i);
+		} else {
+			i = source3();
+			i = add42(i);
+		}
+		// Join of three abstractions into one successor with two neighbors
+		// where the neighbors only differ in their corresponding call site
+		cm.publish(i);
+	}
 }

--- a/soot-infoflow/test/soot/jimple/infoflow/test/junit/OtherTests.java
+++ b/soot-infoflow/test/soot/jimple/infoflow/test/junit/OtherTests.java
@@ -437,4 +437,14 @@ public abstract class OtherTests extends JUnitTests {
 		Assert.assertTrue(infoflow.getResults().isPathBetweenMethods(sink, sourceDeviceId));
 	}
 
+
+	@Test(timeout = 300000)
+	public void testNeighbors1() {
+		IInfoflow infoflow = initInfoflow();
+		List<String> epoints = new ArrayList<String>();
+		epoints.add("<soot.jimple.infoflow.test.OtherTestCode: void testNeighbors1()>");
+		infoflow.computeInfoflow(appPath, libPath, epoints, sources, sinks);
+		checkInfoflow(infoflow, 1);
+		Assert.assertEquals(3, infoflow.getResults().getResultSet().size());
+	}
 }


### PR DESCRIPTION
This fixes non-deterministic results in cases whenever there are more than 1 neighbors with equal statements, i.e. joining after returning from a function.