### PR TITLE
Fix bug in instrumentOnBind method at ServiceEntryPointCreator.java

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceEntryPointCreator.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/entryPointCreators/components/ServiceEntryPointCreator.java
@@ -169,7 +169,7 @@ public class ServiceEntryPointCreator extends AbstractComponentEntryPointCreator
 		SootMethod sm = component.getMethodUnsafe("android.os.IBinder onBind(android.content.Intent)");
 		final Type intentType = RefType.v("android.content.Intent");
 		final Type binderType = RefType.v("android.os.IBinder");
-		if (sm == null || !sm.hasActiveBody()) {
+		if (sm == null || !sm.isConcrete()) {
 			// Create a new onBind() method
 			if (sm == null) {
 				sm = Scene.v().makeSootMethod("onBind", Collections.singletonList(intentType), binderType,
@@ -192,7 +192,7 @@ public class ServiceEntryPointCreator extends AbstractComponentEntryPointCreator
 			b.getUnits().add(Jimple.v().newReturnStmt(binderLocal));
 		} else {
 			// Modify the existing onBind() method
-			JimpleBody b = (JimpleBody) sm.getActiveBody();
+			JimpleBody b = (JimpleBody) sm.retrieveActiveBody();
 			Stmt firstNonIdentityStmt = b.getFirstNonIdentityStmt();
 
 			final Local thisLocal = b.getThisLocal();


### PR DESCRIPTION
During the instrumentOnBind process, the sm.hasActiveBody() function consistently yields a null result. This is because the body retrieval for the activeBody hasn't occurred at that moment. Consequently, despite the onBind method being overridden within the corresponding service component, the activeBody within the "onbind" method always remains null. Flowdroid's instrumentOnBind function in ServiceEntryPointCreator will rewrite all methods with the subsignature "android.os.IBinder onBind(android.content.Intent). So that the corresponding callgraph for each onBind method in the Service component would suffer.