### PR TITLE
Fix expected result of runTestServiceEventSequence3

### DIFF
--- a/soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/LifecycleTest.java
+++ b/soot-infoflow-android/test/soot/jimple/infoflow/android/test/droidBench/LifecycleTest.java
@@ -201,12 +201,9 @@ public abstract class LifecycleTest extends JUnitTests {
 
 	@Test(timeout = 300000)
 	public void runTestServiceEventSequence3() throws IOException, XmlPullParserException {
-		int expected = 1;
-		if (mode == TestResultMode.FLOWDROID_BACKWARDS || mode == TestResultMode.FLOWDROID_FORWARDS)
-			expected = 0;
 		InfoflowResults res = analyzeAPKFile("Lifecycle/ServiceEventSequence3.apk");
 		Assert.assertNotNull(res);
-		Assert.assertEquals(expected, res.size());
+		Assert.assertEquals(1, res.size());
 	}
 
 	@Test(timeout = 300000)


### PR DESCRIPTION
PR #694 fixed a bug in the onBind handling, changing the expected result in one DroidBench lifecycle test.