### PR TITLE
Fix: different methods were considered as the same

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/data/AndroidMethod.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/data/AndroidMethod.java
@@ -164,6 +164,11 @@ public class AndroidMethod extends SootMethodAndClass {
 			return false;
 		if (sourceSinkType != other.sourceSinkType)
 			return false;
+		if (!this.className.equals(other.className)
+		    || !this.methodName.equals(other.methodName)
+		    || !this.returnType.equals(other.returnType)) {
+			return false;
+		}
 		return true;
 	}
 

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/data/AndroidMethod.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/data/AndroidMethod.java
@@ -164,11 +164,6 @@ public class AndroidMethod extends SootMethodAndClass {
 			return false;
 		if (sourceSinkType != other.sourceSinkType)
 			return false;
-		if (!this.className.equals(other.className)
-		    || !this.methodName.equals(other.methodName)
-		    || !this.returnType.equals(other.returnType)) {
-			return false;
-		}
 		return true;
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/data/SootMethodAndClass.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/data/SootMethodAndClass.java
@@ -70,6 +70,8 @@ public class SootMethodAndClass extends AbstractMethodAndClass {
 			return false;
 		if (!this.className.equals(otherMethod.className))
 			return false;
+		if (!this.returnType.equals(otherMethod.returnType))
+			return false;
 		return true;
 	}
 


### PR DESCRIPTION
Two methods that are different are considered as the same because of the way the `equals()` method is implemented:

<img width="800" alt="before_fix" src="https://github.com/secure-software-engineering/FlowDroid/assets/35679728/87f57f60-10e9-44d3-bb93-ad6e2e545fab">

After the small fix:

<img width="800" alt="after_fix" src="https://github.com/secure-software-engineering/FlowDroid/assets/35679728/b340be28-3ef3-4648-93ed-3b46f326edff">
