### PR TITLE
FlowDroid: Clears für Setter nachtragen

### DIFF
--- a/soot-infoflow-summaries/summariesManual/android.content.Intent.xml
+++ b/soot-infoflow-summaries/summariesManual/android.content.Intent.xml
@@ -1406,7 +1406,12 @@
 			</flows>
 		</method>
 		<method id="void setClipData(android.content.ClipData)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.content.Intent: android.content.ClipData clipData]"
+						AccessPathTypes="[android.content.ClipData]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -1512,7 +1517,12 @@
 			</flows>
 		</method>
 		<method id="void setSelector(android.content.Intent)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.content.Intent"
+						AccessPath="[android.content.Intent: android.content.Intent selector]"
+						AccessPathTypes="[android.content.Intent]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.content.Intent"

--- a/soot-infoflow-summaries/summariesManual/android.graphics.Bitmap.xml
+++ b/soot-infoflow-summaries/summariesManual/android.graphics.Bitmap.xml
@@ -599,17 +599,6 @@
             </flows>
         </method>
         <method id="void setPixel(int,int,int)">
-            <clears>
-            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
-                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
-                        AccessPathTypes="[int]" />
-            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
-                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
-                        AccessPathTypes="[int]" />
-            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
-                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
-                        AccessPathTypes="[int]" />
-             </clears>
              <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
@@ -632,11 +621,6 @@
             </flows>
         </method>
         <method id="void setPixels(int[],int,int,int,int,int,int)">
-            <clears>
-            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
-                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
-                        AccessPathTypes="[int]" />
-             </clears>
              <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="2" />

--- a/soot-infoflow-summaries/summariesManual/android.graphics.Bitmap.xml
+++ b/soot-infoflow-summaries/summariesManual/android.graphics.Bitmap.xml
@@ -509,7 +509,12 @@
             </flows>
         </method>
         <method id="void setDensity(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mDensity&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -519,7 +524,12 @@
             </flows>
         </method>
         <method id="void setHasAlpha(boolean)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: boolean mHasAlpha&gt;]"
+                        AccessPathTypes="[boolean]" taintSubFields="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -529,7 +539,12 @@
             </flows>
         </method>
         <method id="void setHasMipMap(boolean)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: boolean mHasMipMap&gt;]"
+                        AccessPathTypes="[boolean]" taintSubFields="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -539,7 +554,12 @@
             </flows>
         </method>
         <method id="void setHeight(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mHeight&gt;]"
+                        AccessPathTypes="[int]" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -549,7 +569,12 @@
             </flows>
         </method>
         <method id="void setLayoutBounds(int[])">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int[] mLayoutBounds&gt;]"
+                        AccessPathTypes="[int[]]" taintSubFields="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int[]" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -559,7 +584,12 @@
             </flows>
         </method>
         <method id="void setNinePatchChunk(byte[])">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: byte[] mNinePatchChunk&gt;]"
+                        AccessPathTypes="[byte[]]" taintSubFields="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="byte[]" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -569,7 +599,18 @@
             </flows>
         </method>
         <method id="void setPixel(int,int,int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
+                        AccessPathTypes="[int]" />
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
+                        AccessPathTypes="[int]" />
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
+                        AccessPathTypes="[int]" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -591,7 +632,12 @@
             </flows>
         </method>
         <method id="void setPixels(int[],int,int,int,int,int,int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mNativeBitmap&gt;]"
+                        AccessPathTypes="[int]" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="2" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -601,7 +647,12 @@
             </flows>
         </method>
         <method id="void setPremultiplied(boolean)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: boolean mPremultiplied&gt;]"
+                        AccessPathTypes="[boolean]" taintSubFields="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"
@@ -611,7 +662,12 @@
             </flows>
         </method>
         <method id="void setWidth(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.graphics.Bitmap"
+                        AccessPath="[&lt;android.graphics.Bitmap: int mWidth&gt;]"
+                        AccessPathTypes="[int]" />
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" />
                     <to sourceSinkType="Field" BaseType="android.graphics.Bitmap"

--- a/soot-infoflow-summaries/summariesManual/android.graphics.Point.xml
+++ b/soot-infoflow-summaries/summariesManual/android.graphics.Point.xml
@@ -102,7 +102,15 @@
 			</flows>
 		</method>
 		<method id="void set(int,int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.graphics.Point"
+						AccessPath="[android.graphics.Point: int y]"
+						AccessPathTypes="[int]" />
+				<clear sourceSinkType="Field" BaseType="android.graphics.Point"
+						AccessPath="[android.graphics.Point: int x]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true">
 					<from sourceSinkType="Parameter" ParameterIndex="1" BaseType="int" />
 					<to sourceSinkType="Field" BaseType="android.graphics.Point"

--- a/soot-infoflow-summaries/summariesManual/android.graphics.PointF.xml
+++ b/soot-infoflow-summaries/summariesManual/android.graphics.PointF.xml
@@ -102,7 +102,15 @@
 			</flows>
 		</method>
 		<method id="void set(android.graphics.PointF)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.graphics.PointF"
+						AccessPath="[android.graphics.PointF: float y]"
+						AccessPathTypes="[float]" />
+				<clear sourceSinkType="Field" BaseType="android.graphics.PointF"
+						AccessPath="[android.graphics.PointF: float x]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true">
 					<from sourceSinkType="Parameter" ParameterIndex="1"
 						BaseType="android.graphics.PointF"
@@ -124,7 +132,15 @@
 			</flows>
 		</method>
 		<method id="void set(float,float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.graphics.PointF"
+						AccessPath="[android.graphics.PointF: float y]"
+						AccessPathTypes="[float]" />
+				<clear sourceSinkType="Field" BaseType="android.graphics.PointF"
+						AccessPath="[android.graphics.PointF: float x]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true">
 					<from sourceSinkType="Parameter" ParameterIndex="1" BaseType="int" />
 					<to sourceSinkType="Field" BaseType="android.graphics.PointF"

--- a/soot-infoflow-summaries/summariesManual/android.graphics.Rect.xml
+++ b/soot-infoflow-summaries/summariesManual/android.graphics.Rect.xml
@@ -266,7 +266,21 @@
 			</flows>
 		</method>
 		<method id="void set(int,int,int,int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.graphics.Rect"
+						AccessPath="[android.graphics.Rect: int left]"
+						AccessPathTypes="[int]" />
+				<clear sourceSinkType="Field" BaseType="android.graphics.Rect"
+						AccessPath="[android.graphics.Rect: int top]"
+						AccessPathTypes="[int]" />
+				<clear sourceSinkType="Field" BaseType="android.graphics.Rect"
+						AccessPath="[android.graphics.Rect: int right]"
+						AccessPathTypes="[int]" />
+				<clear sourceSinkType="Field" BaseType="android.graphics.Rect"
+						AccessPath="[android.graphics.Rect: int bottom]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.graphics.Rect"
@@ -294,7 +308,10 @@
 			</flows>
 		</method>
 		<method id="void set(android.graphics.Rect)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" />

--- a/soot-infoflow-summaries/summariesManual/android.location.Address.xml
+++ b/soot-infoflow-summaries/summariesManual/android.location.Address.xml
@@ -214,10 +214,14 @@
 			</flows>
 		</method>
 		<method id="void setAddressLine(int,java.lang.String)">
+			<constraints>
+                <key sourceSinkType="Parameter" ParameterIndex="0" />
+            </constraints>
 			<clears>
 				<clear sourceSinkType="Field"
 						AccessPath="[android.location.Address: java.lang.String[] addressLines]"
-						AccessPathTypes="[java.lang.String[]]" />
+						AccessPathTypes="[java.lang.String[]]" 
+						constrained="true" />
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/android.location.Address.xml
+++ b/soot-infoflow-summaries/summariesManual/android.location.Address.xml
@@ -214,7 +214,12 @@
 			</flows>
 		</method>
 		<method id="void setAddressLine(int,java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String[] addressLines]"
+						AccessPathTypes="[java.lang.String[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Field"
@@ -224,7 +229,12 @@
 			</flows>
 		</method>
 		<method id="void setAdminArea(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String adminArea]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -234,7 +244,12 @@
 			</flows>
 		</method>
 		<method id="void setCountryCode(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String countryCode]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -244,7 +259,12 @@
 			</flows>
 		</method>
 		<method id="void setCountryName(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String countryName]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -254,7 +274,15 @@
 			</flows>
 		</method>
 		<method id="void setExtras(android.os.Bundle)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.content.Intent"
+						AccessPath="[android.location.Address: java.lang.String[] extraKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				<clear sourceSinkType="Field" BaseType="android.content.Intent"
+						AccessPath="[android.location.Address: java.lang.Object[] extraValues]"
+						AccessPathTypes="[java.lang.Object[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0"
 						AccessPath="[android.location.Address: java.lang.String[] keys]"
@@ -274,7 +302,12 @@
 			</flows>
 		</method>
 		<method id="void setFeatureName(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String featureName]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -284,7 +317,12 @@
 			</flows>
 		</method>
 		<method id="void setLatitude(double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: double latitude]"
+						AccessPathTypes="[double]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -294,7 +332,12 @@
 			</flows>
 		</method>
 		<method id="void setLocality(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String locality]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -304,7 +347,12 @@
 			</flows>
 		</method>
 		<method id="void setLongitude(double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: double longitude]"
+						AccessPathTypes="[double]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -314,7 +362,12 @@
 			</flows>
 		</method>
 		<method id="void setPhone(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String phone]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -324,7 +377,12 @@
 			</flows>
 		</method>
 		<method id="void setPostalCode(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String postalCode]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -334,7 +392,12 @@
 			</flows>
 		</method>
 		<method id="void setPremises(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String premises]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -344,7 +407,12 @@
 			</flows>
 		</method>
 		<method id="void setSubAdminArea(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String subAdminArea]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -354,7 +422,12 @@
 			</flows>
 		</method>
 		<method id="void setSubLocality(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String subLocality]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -364,7 +437,12 @@
 			</flows>
 		</method>
 		<method id="void setSubThoroughfare(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String subThoroughfare]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -374,7 +452,12 @@
 			</flows>
 		</method>
 		<method id="void setUrl(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.location.Address: java.lang.String url]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/android.location.Criteria.xml
+++ b/soot-infoflow-summaries/summariesManual/android.location.Criteria.xml
@@ -110,7 +110,12 @@
 			</flows>
 		</method>
 		<method id="void setAccuracy(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: int accuracy]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -120,7 +125,12 @@
 			</flows>
 		</method>
 		<method id="void setAltitudeRequired(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: boolean altitudeRequired]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -130,7 +140,12 @@
 			</flows>
 		</method>
 		<method id="void setBearingAccuracy(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: int bearingAccuracy]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -140,7 +155,12 @@
 			</flows>
 		</method>
 		<method id="void setBearingRequired(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: boolean bearingRequired]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -150,7 +170,12 @@
 			</flows>
 		</method>
 		<method id="void setCostAllowed(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: boolean costAllowed]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -160,7 +185,12 @@
 			</flows>
 		</method>
 		<method id="void setHorizontalAccuracy(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: int horizontalAccuracy]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -170,7 +200,12 @@
 			</flows>
 		</method>
 		<method id="void setPowerRequirement(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: int powerRequirement]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -180,7 +215,12 @@
 			</flows>
 		</method>
 		<method id="void setSpeedAccuracy(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: int speedAccuracy]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -190,7 +230,12 @@
 			</flows>
 		</method>
 		<method id="void setSpeedRequired(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: boolean speedRequired]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"
@@ -200,7 +245,12 @@
 			</flows>
 		</method>
 		<method id="void setVerticalAccuracy(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Criteria"
+						AccessPath="[android.location.Criteria: int verticalAccuracy]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Criteria"

--- a/soot-infoflow-summaries/summariesManual/android.location.Location.xml
+++ b/soot-infoflow-summaries/summariesManual/android.location.Location.xml
@@ -248,7 +248,10 @@
 			</clears>
 		</method>
 		<method id="void set(android.location.Location)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location" />
@@ -256,7 +259,12 @@
 			</flows>
 		</method>
 		<method id="void setAccuracy(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: float accuracy]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -266,7 +274,12 @@
 			</flows>
 		</method>
 		<method id="void setAltitude(double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: double altitude]"
+						AccessPathTypes="[double]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -276,7 +289,12 @@
 			</flows>
 		</method>
 		<method id="void setBearing(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: float bearing]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -286,7 +304,12 @@
 			</flows>
 		</method>
 		<method id="void setBearingAccuracyDegrees(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: float bearingAccuracy]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -296,7 +319,15 @@
 			</flows>
 		</method>
 		<method id="void setExtras(android.os.Bundle)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.content.Intent"
+						AccessPath="[android.location.Location: java.lang.String[] extraKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				<clear sourceSinkType="Field" BaseType="android.content.Intent"
+						AccessPath="[android.location.Location: java.lang.Object[] extraValues]"
+						AccessPathTypes="[java.lang.Object[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0"
 						AccessPath="[android.location.Location: java.lang.String[] keys]"
@@ -316,7 +347,12 @@
 			</flows>
 		</method>
 		<method id="void setLatitude(double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: double latitude]"
+						AccessPathTypes="[double]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -326,7 +362,12 @@
 			</flows>
 		</method>
 		<method id="void setLongitude(double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: double longitude]"
+						AccessPathTypes="[double]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -336,7 +377,12 @@
 			</flows>
 		</method>
 		<method id="void setProvider(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: java.lang.String provider]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -346,7 +392,12 @@
 			</flows>
 		</method>
 		<method id="void setSpeed(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: float speed]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -356,7 +407,12 @@
 			</flows>
 		</method>
 		<method id="void setSpeedAccuracyMetersPerSecond(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: float speedAccuracy]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"
@@ -366,7 +422,12 @@
 			</flows>
 		</method>
 		<method id="void setVerticalAccuracyMeters(float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="android.location.Location"
+						AccessPath="[android.location.Location: float verticalAccuracy]"
+						AccessPathTypes="[float]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="android.location.Location"

--- a/soot-infoflow-summaries/summariesManual/android.util.JsonWriter.xml
+++ b/soot-infoflow-summaries/summariesManual/android.util.JsonWriter.xml
@@ -64,7 +64,11 @@
 			</flows>
 		</method>
 		<method id="void setIndent(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[android.util.JsonWriter: java.io.Writer writer]"
+						AccessPathTypes="[java.io.Writer]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" AccessPath="[android.util.JsonWriter: java.io.Writer writer]"

--- a/soot-infoflow-summaries/summariesManual/android.util.JsonWriter.xml
+++ b/soot-infoflow-summaries/summariesManual/android.util.JsonWriter.xml
@@ -64,11 +64,7 @@
 			</flows>
 		</method>
 		<method id="void setIndent(java.lang.String)">
-			<clears>
-				<clear sourceSinkType="Field" AccessPath="[android.util.JsonWriter: java.io.Writer writer]"
-						AccessPathTypes="[java.io.Writer]" />
-			 </clears>
-			 <flows> 
+			<flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" AccessPath="[android.util.JsonWriter: java.io.Writer writer]"

--- a/soot-infoflow-summaries/summariesManual/android.util.SparseArray.xml
+++ b/soot-infoflow-summaries/summariesManual/android.util.SparseArray.xml
@@ -112,10 +112,15 @@
             </clears>
         </method>
         <method id="void setValueAt(int,java.lang.Object)">
+			<constraints>
+                <key sourceSinkType="Parameter" ParameterIndex="0" />
+            </constraints>
             <clears>
             	<clear sourceSinkType="Field" BaseType="android.util.SparseArray"
                         AccessPath="[android.util.SparseArray: byte[] data]"
-                        AccessPathTypes="[byte[]]" />
+                        AccessPathTypes="[byte[]]" 
+                        constrained="true" 
+                        isAlias="true" />
              </clears>
              <flows> 
                 <flow isAlias="true" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/android.util.SparseArray.xml
+++ b/soot-infoflow-summaries/summariesManual/android.util.SparseArray.xml
@@ -3,14 +3,14 @@
     <methods>
         <method id="void append(int,java.lang.Object)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <flows>
                 <flow isAlias="true" typeChecking="false" final="true">
                     <from sourceSinkType="Parameter" ParameterIndex="1" />
                     <to sourceSinkType="Field" BaseType="android.util.SparseArray"
-                        AccessPath="[android.util.SparseArray: byte[] data]"
-                        AccessPathTypes="[byte[]]"
+                        AccessPath="[android.util.SparseArray: Object[] mValues]"
+                        AccessPathTypes="[Object[]]"
                         constrained="true" />
                 </flow>
             </flows>
@@ -18,28 +18,29 @@
         <method id="void clear()">
             <clears>
                 <clear sourceSinkType="Field"
-                       AccessPath="[android.util.SparseArray: byte[] data]" />
+                       AccessPath="[android.util.SparseArray: Object[] mValues]" 
+                       constrained="true"/>
             </clears>
         </method>
         <method id="void delete(int)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <clears>
                 <clear sourceSinkType="Field"
-                       AccessPath="[android.util.SparseArray: byte[] data]"
+                       AccessPath="[android.util.SparseArray: Object[] mValues]"
                        constrained="true" />
             </clears>
         </method>
         <method id="java.lang.Object get(int)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <flows>
                 <flow isAlias="true" typeChecking="false" final="true">
                     <from sourceSinkType="Field" BaseType="android.util.SparseArray"
-                          AccessPath="[android.util.SparseArray: byte[] data]"
-                          AccessPathTypes="[byte[]]"
+                          AccessPath="[android.util.SparseArray: Object[] mValues]"
+                          AccessPathTypes="[Object[]]"
                           constrained="true" />
                     <to sourceSinkType="Return" />
                 </flow>
@@ -47,13 +48,13 @@
         </method>
         <method id="java.lang.Object get(int,java.lang.Object)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <flows>
                 <flow isAlias="true" typeChecking="false">
                     <from sourceSinkType="Field" BaseType="android.util.SparseArray"
-                          AccessPath="[android.util.SparseArray: byte[] data]"
-                          AccessPathTypes="[byte[]]"
+                          AccessPath="[android.util.SparseArray: Object[] mValues]"
+                          AccessPathTypes="[Object[]]"
                           constrained="true" />
                     <to sourceSinkType="Return" />
                 </flow>
@@ -65,60 +66,60 @@
         </method>
         <method id="void put(int,java.lang.Object)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <flows>
                 <flow isAlias="true" typeChecking="false">
                     <from sourceSinkType="Parameter" ParameterIndex="1" />
                     <to sourceSinkType="Field" BaseType="android.util.SparseArray"
-                        AccessPath="[android.util.SparseArray: byte[] data]"
-                        AccessPathTypes="[byte[]]"
+                        AccessPath="[android.util.SparseArray: Object[] mValues]"
+                        AccessPathTypes="[Object[]]"
                         constrained="true" />
                 </flow>
             </flows>
             <clears>
                 <clear sourceSinkType="Field"
-                       AccessPath="[android.util.SparseArray: byte[] data]"
+                       AccessPath="[android.util.SparseArray: Object[] mValues]"
                        constrained="true" />
             </clears>
         </method>
         <method id="void remove(int)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <clears>
                 <clear sourceSinkType="Field"
-                       AccessPath="[android.util.SparseArray: byte[] data]"
+                       AccessPath="[android.util.SparseArray: Object[] mValues]"
                        constrained="true" />
             </clears>
         </method>
         <method id="void set(int,java.lang.Object)">
             <constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <flows>
                 <flow isAlias="true" typeChecking="false">
                     <from sourceSinkType="Parameter" ParameterIndex="1" />
                     <to sourceSinkType="Field" BaseType="android.util.SparseArray"
-                        AccessPath="[android.util.SparseArray: byte[] data]"
-                        AccessPathTypes="[byte[]]"
+                        AccessPath="[android.util.SparseArray: Object[] mValues]"
+                        AccessPathTypes="[Object[]]"
                         constrained="true" />
                 </flow>
             </flows>
             <clears>
                 <clear sourceSinkType="Field"
-                       AccessPath="[android.util.SparseArray: byte[] data]"
+                       AccessPath="[android.util.SparseArray: Object[] mValues]"
                        constrained="true" />
             </clears>
         </method>
         <method id="void setValueAt(int,java.lang.Object)">
 			<constraints>
-                <key sourceSinkType="Parameter" ParameterIndex="0" />
+                <index sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
             <clears>
             	<clear sourceSinkType="Field" BaseType="android.util.SparseArray"
-                        AccessPath="[android.util.SparseArray: byte[] data]"
-                        AccessPathTypes="[byte[]]" 
+                        AccessPath="[android.util.SparseArray: Object[] mValues]"
+                        AccessPathTypes="[Object[]]" 
                         constrained="true" 
                         isAlias="true" />
              </clears>
@@ -126,8 +127,8 @@
                 <flow isAlias="true" typeChecking="false">
                     <from sourceSinkType="Parameter" ParameterIndex="1" />
                     <to sourceSinkType="Field" BaseType="android.util.SparseArray"
-                        AccessPath="[android.util.SparseArray: byte[] data]"
-                        AccessPathTypes="[byte[]]" />
+                        AccessPath="[android.util.SparseArray: Object[] mValues]"
+                        AccessPathTypes="[Object[]]" />
                 </flow>
             </flows>
         </method>
@@ -135,8 +136,8 @@
             <flows>
                 <flow isAlias="true" typeChecking="false">
                     <from sourceSinkType="Field" BaseType="android.util.SparseArray"
-                          AccessPath="[android.util.SparseArray: byte[] data]"
-                          AccessPathTypes="[byte[]]" />
+                          AccessPath="[android.util.SparseArray: Object[] mValues]"
+                          AccessPathTypes="[Object[]]" />
                     <to sourceSinkType="Return" />
                 </flow>
             </flows>

--- a/soot-infoflow-summaries/summariesManual/android.util.SparseArray.xml
+++ b/soot-infoflow-summaries/summariesManual/android.util.SparseArray.xml
@@ -112,7 +112,12 @@
             </clears>
         </method>
         <method id="void setValueAt(int,java.lang.Object)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="android.util.SparseArray"
+                        AccessPath="[android.util.SparseArray: byte[] data]"
+                        AccessPathTypes="[byte[]]" />
+             </clears>
+             <flows> 
                 <flow isAlias="true" typeChecking="false">
                     <from sourceSinkType="Parameter" ParameterIndex="1" />
                     <to sourceSinkType="Field" BaseType="android.util.SparseArray"

--- a/soot-infoflow-summaries/summariesManual/android.widget.CheckBox.xml
+++ b/soot-infoflow-summaries/summariesManual/android.widget.CheckBox.xml
@@ -11,7 +11,11 @@
 			</flows>
 		</method>
 		<method id="void setChecked(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[android.widget.CheckBox: boolean isChecked]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" AccessPath="[android.widget.CheckBox: boolean isChecked]"

--- a/soot-infoflow-summaries/summariesManual/android.widget.EditText.xml
+++ b/soot-infoflow-summaries/summariesManual/android.widget.EditText.xml
@@ -62,7 +62,12 @@
 			</flows>
 		</method>
 		<method id="void setError(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: java.lang.CharSequence error]"
+						AccessPathTypes="[java.lang.CharSequence]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -72,7 +77,12 @@
 			</flows>
 		</method>
 		<method id="void setHint(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: java.lang.CharSequence hint]"
+						AccessPathTypes="[java.lang.CharSequence]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -82,7 +92,12 @@
 			</flows>
 		</method>
 		<method id="void setText(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: android.text.Editable content,android.text.Editable: java.lang.String content]"
+						AccessPathTypes="[android.text.Editable,java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -92,7 +107,12 @@
 			</flows>
 		</method>
 		<method id="void setText(java.lang.CharSequence,android.widget.TextView$BufferType)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: android.text.Editable content,android.text.Editable: java.lang.String content]"
+						AccessPathTypes="[android.text.Editable,java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -102,7 +122,12 @@
 			</flows>
 		</method>
 		<method id="void setText(char[],int,int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: android.text.Editable content,android.text.Editable: java.lang.String content]"
+						AccessPathTypes="[android.text.Editable,java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/android.widget.TextView.xml
+++ b/soot-infoflow-summaries/summariesManual/android.widget.TextView.xml
@@ -62,7 +62,12 @@
 			</flows>
 		</method>
 		<method id="void setError(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: java.lang.CharSequence error]"
+						AccessPathTypes="[java.lang.CharSequence]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -72,7 +77,12 @@
 			</flows>
 		</method>
 		<method id="void setHint(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: java.lang.CharSequence hint]"
+						AccessPathTypes="[java.lang.CharSequence]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -82,7 +92,12 @@
 			</flows>
 		</method>
 		<method id="void setText(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: android.text.Editable content,android.text.Editable: java.lang.String content]"
+						AccessPathTypes="[android.text.Editable,java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -92,7 +107,12 @@
 			</flows>
 		</method>
 		<method id="void setText(java.lang.CharSequence,android.widget.TextView$BufferType)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: android.text.Editable content,android.text.Editable: java.lang.String content]"
+						AccessPathTypes="[android.text.Editable,java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -102,7 +122,12 @@
 			</flows>
 		</method>
 		<method id="void setText(char[],int,int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.TextView: android.text.Editable content,android.text.Editable: java.lang.String content]"
+						AccessPathTypes="[android.text.Editable,java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/android.widget.Toast.xml
+++ b/soot-infoflow-summaries/summariesManual/android.widget.Toast.xml
@@ -48,7 +48,12 @@
 			</flows>
 		</method>
 		<method id="void setDuration(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.Toast: int duration]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -58,7 +63,12 @@
 			</flows>
 		</method>
 		<method id="void setText(java.lang.CharSequence)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.Toast: java.lang.CharSequence text]"
+						AccessPathTypes="[java.lang.CharSequence]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -68,7 +78,12 @@
 			</flows>
 		</method>
 		<method id="void setView(android.view.View)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[android.widget.Toast: android.view.View view]"
+						AccessPathTypes="[android.view.View]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/com.baidu.location.BDLocation.xml
+++ b/soot-infoflow-summaries/summariesManual/com.baidu.location.BDLocation.xml
@@ -25,7 +25,12 @@
             </flows>
         </method>
         <method id="void setAddrStr(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String p&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -55,7 +60,12 @@
             </flows>
         </method>
         <method id="void setUserIndoorState(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int E&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -65,7 +75,12 @@
             </flows>
         </method>
         <method id="void setParkAvailable(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int z&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -95,7 +110,15 @@
             </flows>
         </method>
         <method id="void setTime(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String b&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String N&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -131,7 +154,12 @@
             </flows>
         </method>
         <method id="void setPoiList(java.util.List)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.util.List L&gt;]"
+                        AccessPathTypes="[java.util.List]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="true">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.util.List"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -151,7 +179,12 @@
             </flows>
         </method>
         <method id="void setLatitude(double)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: double c&gt;]"
+                        AccessPathTypes="[double]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="double"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -161,7 +194,12 @@
             </flows>
         </method>
         <method id="void setBuildingName(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String x&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -181,7 +219,12 @@
             </flows>
         </method>
         <method id="void setLocType(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int a&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -191,7 +234,12 @@
             </flows>
         </method>
         <method id="void setLocationID(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String N&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -221,7 +269,12 @@
             </flows>
         </method>
         <method id="void setGpsCheckStatus(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int Q&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -241,7 +294,12 @@
             </flows>
         </method>
         <method id="void setCoorType(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String n&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -251,7 +309,12 @@
             </flows>
         </method>
         <method id="void setGpsAccuracyStatus(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int P&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -291,7 +354,12 @@
             </flows>
         </method>
         <method id="void setLocationDescribe(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String q&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -301,7 +369,12 @@
             </flows>
         </method>
         <method id="void setAltitude(double)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: double f&gt;]"
+                        AccessPathTypes="[double]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="double"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -311,7 +384,12 @@
             </flows>
         </method>
         <method id="void setIndoorSurpportPolygon(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String K&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -341,7 +419,12 @@
             </flows>
         </method>
         <method id="void setBuildingID(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String w&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -351,7 +434,12 @@
             </flows>
         </method>
         <method id="void setLongitude(double)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: double d&gt;]"
+                        AccessPathTypes="[double]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="double"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -391,7 +479,12 @@
             </flows>
         </method>
         <method id="void setLocationWhere(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int A&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -421,7 +514,12 @@
             </flows>
         </method>
         <method id="void setNetworkLocationType(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String B&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -431,7 +529,12 @@
             </flows>
         </method>
         <method id="void setSatelliteNumber(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int l&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -481,7 +584,12 @@
             </flows>
         </method>
         <method id="void setIndoorLocMode(boolean)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: boolean y&gt;]"
+                        AccessPathTypes="[boolean]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="boolean"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -521,7 +629,12 @@
             </flows>
         </method>
         <method id="void setIndoorNetworkState(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int G&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -541,7 +654,12 @@
             </flows>
         </method>
         <method id="void setDirection(float)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: float m&gt;]"
+                        AccessPathTypes="[float]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="float"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -609,7 +727,12 @@
             </flows>
         </method>
         <method id="void setIndoorLocationSurpport(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int F&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -619,7 +742,12 @@
             </flows>
         </method>
         <method id="void setFloor(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String v&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -639,7 +767,12 @@
             </flows>
         </method>
         <method id="void setAddr(com.baidu.location.Address)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: com.baidu.location.Address u&gt;]"
+                        AccessPathTypes="[com.baidu.location.Address]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="true">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="com.baidu.location.Address"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -649,7 +782,12 @@
             </flows>
         </method>
         <method id="void setRadius(float)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: float j&gt;]"
+                        AccessPathTypes="[float]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="float"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -659,7 +797,12 @@
             </flows>
         </method>
         <method id="void setSpeed(float)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: float h&gt;]"
+                        AccessPathTypes="[float]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="float"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -749,7 +892,12 @@
             </flows>
         </method>
         <method id="void setLocTypeDescription(java.lang.String)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: java.lang.String M&gt;]"
+                        AccessPathTypes="[java.lang.String]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.String"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -779,7 +927,12 @@
             </flows>
         </method>
         <method id="void setIndoorLocationSource(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int H&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
@@ -809,7 +962,12 @@
             </flows>
         </method>
         <method id="void setOperators(int)">
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"
+                        AccessPath="[&lt;com.baidu.location.BDLocation: int C&gt;]"
+                        AccessPathTypes="[int]" taintSubFields="true">
+             </clears>
+             <flows> 
                 <flow isAlias="false">
                     <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="int"></from>
                     <to sourceSinkType="Field" BaseType="com.baidu.location.BDLocation"

--- a/soot-infoflow-summaries/summariesManual/java.lang.StringBuffer.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.StringBuffer.xml
@@ -429,9 +429,11 @@
 			</flows>
 		</method>
 		<method id="void setCharAt(int,char)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="0" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Field" 
-						 />
+				<clear sourceSinkType="Field" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/java.lang.StringBuffer.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.StringBuffer.xml
@@ -429,7 +429,11 @@
 			</flows>
 		</method>
 		<method id="void setCharAt(int,char)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" 
+						 />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Field" 

--- a/soot-infoflow-summaries/summariesManual/java.lang.StringBuilder.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.StringBuilder.xml
@@ -399,7 +399,11 @@
 			</flows>
 		</method>
 		<method id="void setCharAt(int,char)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						/>
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.lang.StringBuilder.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.StringBuilder.xml
@@ -399,9 +399,11 @@
 			</flows>
 		</method>
 		<method id="void setCharAt(int,char)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="0" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Field"
-						/>
+				<clear sourceSinkType="Field" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/java.lang.Thread.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.Thread.xml
@@ -148,7 +148,12 @@
 			</flows>
 		</method>
 		<method id="void setName(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.lang.Thread"
@@ -158,7 +163,12 @@
 			</flows>
 		</method>
 		<method id="void setPriority(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: int priority]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.lang.Thread"

--- a/soot-infoflow-summaries/summariesManual/java.lang.ThreadLocal.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.ThreadLocal.xml
@@ -29,7 +29,12 @@
 			</clears>
 		</method>
 		<method id="void set(java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.lang.ThreadLocal"
+						AccessPath="[java.lang.ThreadLocal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.lang.ThreadLocal"

--- a/soot-infoflow-summaries/summariesManual/java.lang.Throwable.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.Throwable.xml
@@ -138,7 +138,12 @@
 			</flows>
 		</method>
 		<method id="void setStackTrace(java.lang.StackTraceElement[])">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.StackTraceElement[] stackTrace]"
+						AccessPathTypes="[java.lang.StackTraceElement[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.lang.reflect.Array.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.reflect.Array.xml
@@ -74,7 +74,10 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.Object,int,java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -82,7 +85,10 @@
 			</flows>
 		</method>
 		<method id="void setBoolean(java.lang.Object,int,boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -90,7 +96,10 @@
 			</flows>
 		</method>
 		<method id="void setByte(java.lang.Object,int,byte)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -98,7 +107,10 @@
 			</flows>
 		</method>
 		<method id="void setChar(java.lang.Object,int,char)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -106,7 +118,10 @@
 			</flows>
 		</method>
 		<method id="void setShort(java.lang.Object,int,short)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -114,7 +129,10 @@
 			</flows>
 		</method>
 		<method id="void setInt(java.lang.Object,int,int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -122,7 +140,10 @@
 			</flows>
 		</method>
 		<method id="void setLong(java.lang.Object,int,long)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -130,7 +151,10 @@
 			</flows>
 		</method>
 		<method id="void setFloat(java.lang.Object,int,float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -138,7 +162,10 @@
 			</flows>
 		</method>
 		<method id="void setDouble(java.lang.Object,int,double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />

--- a/soot-infoflow-summaries/summariesManual/java.lang.reflect.Array.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.reflect.Array.xml
@@ -74,8 +74,11 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.Object,int,java.lang.Object)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true" />
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -85,8 +88,11 @@
 			</flows>
 		</method>
 		<method id="void setBoolean(java.lang.Object,int,boolean)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -96,8 +102,11 @@
 			</flows>
 		</method>
 		<method id="void setByte(java.lang.Object,int,byte)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -107,8 +116,11 @@
 			</flows>
 		</method>
 		<method id="void setChar(java.lang.Object,int,char)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -118,8 +130,11 @@
 			</flows>
 		</method>
 		<method id="void setShort(java.lang.Object,int,short)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -129,8 +144,11 @@
 			</flows>
 		</method>
 		<method id="void setInt(java.lang.Object,int,int)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -140,8 +158,11 @@
 			</flows>
 		</method>
 		<method id="void setLong(java.lang.Object,int,long)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -151,8 +172,11 @@
 			</flows>
 		</method>
 		<method id="void setFloat(java.lang.Object,int,float)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
@@ -162,8 +186,11 @@
 			</flows>
 		</method>
 		<method id="void setDouble(java.lang.Object,int,double)">
+			<constraints>
+				<index sourceSinkType="Parameter" ParameterIndex="1" />
+			</constraints>
 			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+				<clear sourceSinkType="Parameter" ParameterIndex="0" constrained="true"/>
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/java.lang.reflect.Field.xml
+++ b/soot-infoflow-summaries/summariesManual/java.lang.reflect.Field.xml
@@ -90,7 +90,10 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.Object,java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -98,7 +101,10 @@
 			</flows>
 		</method>
 		<method id="void setBoolean(java.lang.Object,boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -106,7 +112,10 @@
 			</flows>
 		</method>
 		<method id="void setByte(java.lang.Object,byte)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -114,7 +123,10 @@
 			</flows>
 		</method>
 		<method id="void setChar(java.lang.Object,char)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -122,7 +134,10 @@
 			</flows>
 		</method>
 		<method id="void setShort(java.lang.Object,short)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -130,7 +145,10 @@
 			</flows>
 		</method>
 		<method id="void setInt(java.lang.Object,int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -138,7 +156,10 @@
 			</flows>
 		</method>
 		<method id="void setLong(java.lang.Object,long)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -146,7 +167,10 @@
 			</flows>
 		</method>
 		<method id="void setFloat(java.lang.Object,float)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />
@@ -154,7 +178,10 @@
 			</flows>
 		</method>
 		<method id="void setDouble(java.lang.Object,double)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Parameter" ParameterIndex="0" />

--- a/soot-infoflow-summaries/summariesManual/java.net.HttpCookie.xml
+++ b/soot-infoflow-summaries/summariesManual/java.net.HttpCookie.xml
@@ -196,7 +196,12 @@
 			</flows>
 		</method>
 		<method id="void setComment(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: java.lang.String comment]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -206,7 +211,12 @@
 			</flows>
 		</method>
 		<method id="void setCommentURL(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: java.lang.String commentURL]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -216,7 +226,12 @@
 			</flows>
 		</method>
 		<method id="void setDiscard(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: boolean discard]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -226,7 +241,12 @@
 			</flows>
 		</method>
 		<method id="void setDomain(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: java.lang.String domain]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -236,7 +256,12 @@
 			</flows>
 		</method>
 		<method id="void setHttpOnly(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: boolean httpOnly]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -246,7 +271,12 @@
 			</flows>
 		</method>
 		<method id="void setMaxAge(long)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: long maxAge]"
+						AccessPathTypes="[long]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -256,7 +286,12 @@
 			</flows>
 		</method>
 		<method id="void setPath(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -266,7 +301,12 @@
 			</flows>
 		</method>
 		<method id="void setPortlist(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: java.lang.String portlist]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -276,7 +316,12 @@
 			</flows>
 		</method>
 		<method id="void setSecure(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: boolean secure]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -286,7 +331,12 @@
 			</flows>
 		</method>
 		<method id="void setValue(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: java.lang.String value]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"
@@ -296,7 +346,12 @@
 			</flows>
 		</method>
 		<method id="void setVersion(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.HttpCookie"
+						AccessPath="[java.net.HttpCookie: int version]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.HttpCookie"

--- a/soot-infoflow-summaries/summariesManual/java.net.URL.xml
+++ b/soot-infoflow-summaries/summariesManual/java.net.URL.xml
@@ -324,7 +324,24 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.String,java.lang.String,int,java.lang.String,java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URL"
@@ -358,7 +375,30 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.String,java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URL"

--- a/soot-infoflow-summaries/summariesManual/java.net.URLConnection.xml
+++ b/soot-infoflow-summaries/summariesManual/java.net.URLConnection.xml
@@ -299,7 +299,12 @@
 			</flows>
 		</method>
 		<method id="void setAllowUserInteraction(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean allowUserInteraction]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -309,7 +314,12 @@
 			</flows>
 		</method>
 		<method id="void setConnectTimeout(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: int connectTimeout]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -319,7 +329,12 @@
 			</flows>
 		</method>
 		<method id="void setDefaultUseCaches(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean defaultUseCaches]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -329,7 +344,12 @@
 			</flows>
 		</method>
 		<method id="void setDoInput(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean doInput]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -339,7 +359,12 @@
 			</flows>
 		</method>
 		<method id="void setDoOutput(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean doOutput]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -349,7 +374,12 @@
 			</flows>
 		</method>
 		<method id="void setIfModifiedSince(long)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: long ifModifiedSince]"
+						AccessPathTypes="[long]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -359,7 +389,12 @@
 			</flows>
 		</method>
 		<method id="void setReadTimeout(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: int readTimeout]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -369,7 +404,15 @@
 			</flows>
 		</method>
 		<method id="void setRequestProperty(java.lang.String,java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
@@ -385,7 +428,12 @@
 			</flows>
 		</method>
 		<method id="void setUseCaches(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean useCaches]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" BaseType="java.net.URLConnection"

--- a/soot-infoflow-summaries/summariesManual/java.util.ListIterator.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.ListIterator.xml
@@ -36,10 +36,6 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.Object)">
-			<clears>
-				<clear sourceSinkType="Field" AccessPath="[java.util.Iterator: java.lang.Object[] innerArray]"
-						AccessPathTypes="[java.lang.Object[]]" />
-			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />

--- a/soot-infoflow-summaries/summariesManual/java.util.ListIterator.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.ListIterator.xml
@@ -36,7 +36,11 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[java.util.Iterator: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" AccessPath="[java.util.Iterator: java.lang.Object[] innerArray]"

--- a/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicBoolean.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicBoolean.xml
@@ -58,7 +58,12 @@
 			</flows>
 		</method>
 		<method id="void set(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[java.util.concurrent.atomic.AtomicBoolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicInteger.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicInteger.xml
@@ -170,7 +170,12 @@
 			</flows>
 		</method>
 		<method id="void set(int)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[java.util.concurrent.atomic.AtomicInteger: int value]"
+						AccessPathTypes="[int]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicLong.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicLong.xml
@@ -170,7 +170,12 @@
 			</flows>
 		</method>
 		<method id="void set(long)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[java.util.concurrent.atomic.AtomicLong: long value]"
+						AccessPathTypes="[long]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicReference.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicReference.xml
@@ -58,7 +58,12 @@
 			</flows>
 		</method>
 		<method id="void set(java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[java.util.concurrent.atomic.AtomicReference: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicReferenceArray.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicReferenceArray.xml
@@ -58,7 +58,12 @@
 			</flows>
 		</method>
 		<method id="void set(int,java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[java.util.concurrent.atomic.AtomicReferenceArray: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="1" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicReferenceArray.xml
+++ b/soot-infoflow-summaries/summariesManual/java.util.concurrent.atomic.AtomicReferenceArray.xml
@@ -58,10 +58,14 @@
 			</flows>
 		</method>
 		<method id="void set(int,java.lang.Object)">
+			<constraints>
+                <key sourceSinkType="Parameter" ParameterIndex="0" />
+            </constraints>
 			<clears>
 				<clear sourceSinkType="Field"
 						AccessPath="[java.util.concurrent.atomic.AtomicReferenceArray: java.lang.Object[] values]"
-						AccessPathTypes="[java.lang.Object[]]" />
+						AccessPathTypes="[java.lang.Object[]]" 
+						constrained="true" />
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/javax.servlet.http.HttpSession.xml
+++ b/soot-infoflow-summaries/summariesManual/javax.servlet.http.HttpSession.xml
@@ -5,7 +5,12 @@
             <constraints>
                 <key sourceSinkType="Parameter" ParameterIndex="0" />
             </constraints>
-            <flows>
+            <clears>
+            	<clear sourceSinkType="Field"
+                        AccessPath="[javax.servlet.http.HttpSession: java.lang.Object[] attributes]"
+                        AccessPathTypes="[java.lang.String[]]" constrained="true" />
+             </clears>
+             <flows> 
                 <flow isAlias="false" typeChecking="false">
                     <from sourceSinkType="Parameter" ParameterIndex="1" />
                     <to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/jdk.internal.misc.Unsafe.xml
+++ b/soot-infoflow-summaries/summariesManual/jdk.internal.misc.Unsafe.xml
@@ -311,7 +311,10 @@
 		</method> <!-- frage am ende -->
 		
 		<method id="void setMemory(java.lang.Object,long,long,byte)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0">
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="3" />
 					<to sourceSinkType="Parameter" ParameterIndex="0"></to>
@@ -320,7 +323,10 @@
 		</method> <!-- how to describe setting relative memory -->
 		
 		<method id="void setMemory(long,long,byte)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0">
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="3" />
 					<to sourceSinkType="Parameter" ParameterIndex="0"></to>

--- a/soot-infoflow-summaries/summariesManual/jdk.internal.misc.Unsafe.xml
+++ b/soot-infoflow-summaries/summariesManual/jdk.internal.misc.Unsafe.xml
@@ -323,12 +323,9 @@
 		</method> <!-- how to describe setting relative memory -->
 		
 		<method id="void setMemory(long,long,byte)">
-			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0">
-			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
-					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0"></to>
 				</flow>
 			</flows>

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpDelete.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpDelete.xml
@@ -24,7 +24,12 @@
 			</flows>
 		</method>
 		<method id="void setURI(java.net.URI)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpRequestBase: java.lang.String uri]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpEntityEnclosingRequestBase.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpEntityEnclosingRequestBase.xml
@@ -17,7 +17,12 @@
 			</flows>
 		</method>
 		<method id="void setEntity(org.apache.http.HttpEntity)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpEntityEnclosingRequestBase: org.apache.http.HttpEntity entity]"
+						AccessPathTypes="[org.apache.http.HttpEntity]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpGet.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpGet.xml
@@ -24,7 +24,12 @@
 			</flows>
 		</method>
 		<method id="void setURI(java.net.URI)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpRequestBase: java.lang.String uri]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpHead.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpHead.xml
@@ -24,7 +24,12 @@
 			</flows>
 		</method>
 		<method id="void setURI(java.net.URI)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpRequestBase: java.lang.String uri]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpOptions.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpOptions.xml
@@ -24,7 +24,12 @@
 			</flows>
 		</method>
 		<method id="void setURI(java.net.URI)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpRequestBase: java.lang.String uri]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpRequestBase.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpRequestBase.xml
@@ -7,7 +7,12 @@
 	</hierarchy>
 	<methods>
 		<method id="void setURI(java.net.URI)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpRequestBase: java.lang.String uri]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpTrace.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.client.methods.HttpTrace.xml
@@ -24,7 +24,12 @@
 			</flows>
 		</method>
 		<method id="void setURI(java.net.URI)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.client.methods.HttpRequestBase: java.lang.String uri]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.apache.http.entity.StringEntity.xml
+++ b/soot-infoflow-summaries/summariesManual/org.apache.http.entity.StringEntity.xml
@@ -91,7 +91,12 @@
 			</flows>
 		</method>
 		<method id="void setChunked(boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.apache.http.entity.AbstractHttpEntity: boolean chunked]"
+						AccessPathTypes="[boolean]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.xml.sax.InputSource.xml
+++ b/soot-infoflow-summaries/summariesManual/org.xml.sax.InputSource.xml
@@ -82,7 +82,12 @@
 			</flows>
 		</method>
 		<method id="void setByteStream(java.io.InputStream)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.InputSource: java.io.InputStream byteStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -92,7 +97,12 @@
 			</flows>
 		</method>
 		<method id="void setCharacterStream(java.io.Reader)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.InputSource: java.io.Reader characterStream]"
+						AccessPathTypes="[java.io.Reader]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -102,7 +112,12 @@
 			</flows>
 		</method>
 		<method id="void setEncoding(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.InputSource: java.lang.String encoding]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -112,7 +127,12 @@
 			</flows>
 		</method>
 		<method id="void setPublicId(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.InputSource: java.lang.String publicId]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -122,7 +142,12 @@
 			</flows>
 		</method>
 		<method id="void setSystemId(java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.InputSource: java.lang.String systemId]"
+						AccessPathTypes="[java.lang.String]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.xml.sax.XMLReader.xml
+++ b/soot-infoflow-summaries/summariesManual/org.xml.sax.XMLReader.xml
@@ -102,13 +102,18 @@
 			</flows>
 		</method>
 		<method id="void setFeature(java.lang.String,boolean)">
+			<constraints>
+				<key sourceSinkType="Parameter" ParameterIndex="0" />
+			</constraints>
 			<clears>
 				<clear sourceSinkType="Field"
 						AccessPath="[org.xml.sax.XMLReader: java.lang.String[] featureKeys]"
-						AccessPathTypes="[java.lang.String[]]" />
+						AccessPathTypes="[java.lang.String[]]" 
+						constrained="true" />
 				<clear sourceSinkType="Field"
 						AccessPath="[org.xml.sax.XMLReader: boolean[] featureValues]"
-						AccessPathTypes="[boolean[]]" />
+						AccessPathTypes="[boolean[]]" 
+						constrained="true" />
 			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">

--- a/soot-infoflow-summaries/summariesManual/org.xml.sax.XMLReader.xml
+++ b/soot-infoflow-summaries/summariesManual/org.xml.sax.XMLReader.xml
@@ -102,7 +102,15 @@
 			</flows>
 		</method>
 		<method id="void setFeature(java.lang.String,boolean)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.XMLReader: java.lang.String[] featureKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xml.sax.XMLReader: boolean[] featureValues]"
+						AccessPathTypes="[boolean[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"

--- a/soot-infoflow-summaries/summariesManual/org.xmlpull.v1.XmlSerializer.xml
+++ b/soot-infoflow-summaries/summariesManual/org.xmlpull.v1.XmlSerializer.xml
@@ -171,7 +171,12 @@
 			</flows>
 		</method>
 		<method id="void setOutput(java.io.OutputStream,java.lang.String)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xmlpull.v1.XmlSerializer: java.io.OutputStream outputStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -181,7 +186,12 @@
 			</flows>
 		</method>
 		<method id="void setOutput(java.io.Writer)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field"
+						AccessPath="[org.xmlpull.v1.XmlSerializer: java.io.Writer writer]"
+						AccessPathTypes="[java.io.Writer]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="true">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field"
@@ -191,7 +201,13 @@
 			</flows>
 		</method>
 		<method id="void setProperty(java.lang.String,java.lang.Object)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[org.xmlpull.v1.XmlSerializer: java.lang.String[] propertyKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				<clear sourceSinkType="Field" AccessPath="[org.xmlpull.v1.XmlSerializer: java.lang.Object[] propertyValues]"
+						AccessPathTypes="[java.lang.Object[]]" />
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="0" />
 					<to sourceSinkType="Field" AccessPath="[org.xmlpull.v1.XmlSerializer: java.lang.String[] propertyKeys]"

--- a/soot-infoflow-summaries/summariesManual/sun.misc.Unsafe.xml
+++ b/soot-infoflow-summaries/summariesManual/sun.misc.Unsafe.xml
@@ -297,9 +297,6 @@
 		</method> <!-- doubt -->
 		
 		<method id="void setMemory(long,long,byte)">
-			<clears>
-				<clear sourceSinkType="Parameter" ParameterIndex="0">
-			 </clears>
 			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />

--- a/soot-infoflow-summaries/summariesManual/sun.misc.Unsafe.xml
+++ b/soot-infoflow-summaries/summariesManual/sun.misc.Unsafe.xml
@@ -285,7 +285,10 @@
 		</method> <!-- frage am ende -->
 		
 		<method id="void setMemory(java.lang.Object,long,long,byte)">
-		<flows>
+		<clears>
+			<clear sourceSinkType="Parameter" ParameterIndex="0">
+		 </clears>
+		 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="3" />
 					<to sourceSinkType="Parameter" ParameterIndex="0"></to>
@@ -294,7 +297,10 @@
 		</method> <!-- doubt -->
 		
 		<method id="void setMemory(long,long,byte)">
-			<flows>
+			<clears>
+				<clear sourceSinkType="Parameter" ParameterIndex="0">
+			 </clears>
+			 <flows> 
 				<flow isAlias="false" typeChecking="false">
 					<from sourceSinkType="Parameter" ParameterIndex="2" />
 					<to sourceSinkType="Parameter" ParameterIndex="0"></to>


### PR DESCRIPTION
- Clears für mehrere Setters.
- Wichtige Annahme: Nur Setters mit Signatur 'void setX' haben Clear-Einträge bekommen. Setters, die bereits Clears hatten, wurden ignoriert.
