### PR TITLE
FIX: RuntimeException "File format violation in type spec table: res1 is not zero offset" with some apps

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
@@ -2651,9 +2651,6 @@ public class ARSCFileParser extends AbstractResourceParser {
 		offset += 1;
 
 		typeSpecTable.res1 = readUInt16(data, offset);
-		if (typeSpecTable.res1 != 0) {
-			raiseFormatViolationIssue("File format violation in type spec table: res1 is not zero", offset);
-		}
 		offset += 2;
 
 		typeSpecTable.entryCount = readUInt32(data, offset);


### PR DESCRIPTION
Hi,

I've been testing some newer apps and have been getting this exception, which does not manifest with older apps
I saw that in the [ResourceTypes.h](https://android.googlesource.com/platform/frameworks/base/+/master/libs/androidfw/include/androidfw/ResourceTypes.h#1411) res1 used to be reserved, but now it corresponds to typesCount and can be >0. 

This fix was tested locally by me and it doesn't seem to manifest any issues, but I'm not aware of possible repercussions.

Hope this helps,
Samuele