### PR TITLE
check for new flags in ResTable_Entry and ResTable_Type

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
@@ -2277,9 +2277,9 @@ public class ARSCFileParser extends AbstractResourceParser {
 						resType.configurations.add(config);
 
 						boolean isSparse = ((typeTable.flags & FLAG_SPARSE) == FLAG_SPARSE);
-						boolean isOffset64 = ((typeTable.flags & FLAG_OFFSET16) == FLAG_OFFSET16);
+						boolean isOffset16 = ((typeTable.flags & FLAG_OFFSET16) == FLAG_OFFSET16);
 
-						if (isOffset64) {
+						if (isOffset16) {
 							throw new RuntimeException("Unsupported resource type entry: FLAG_OFFSET16");
 						}
 


### PR DESCRIPTION
Flowdroid does not recognize certain flags in resource table that had been introduced with Android 14. 

Added checks for those flags so that we get log message or exception when APK makes use of it. This PR does not actually implement the necessary changes for supporting the new structures.