### PR TITLE
Fix type refinement in `SummaryTaintWrapper`

### DIFF
--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/ApiClassClient.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/ApiClassClient.java
@@ -596,4 +596,12 @@ public class ApiClassClient {
 		sink(bvar);
 	}
 
+	public void testTypeNarrowing() {
+		String secret = stringSource();
+		// split: String -> String[]
+		// Tests that getMorePreciseType correctly
+		// keeps the array in the type
+		Object[] splitted = secret.split(";");
+		sink(splitted);
+	}
 }

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/ApiClassClient.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/ApiClassClient.java
@@ -585,7 +585,7 @@ public class ApiClassClient {
 	}
 
 	public void listIrrelevantItemTest() {
-		String secret = TelephonyManager.getDeviceId();
+		String secret = stringSource();
 
 		List<Object> lvar = new ArrayList<>();
 		Boolean bvar = true;
@@ -593,8 +593,7 @@ public class ApiClassClient {
 		lvar.add(secret); // Adds tainted data to the list
 		lvar.add(bvar);
 
-		ConnectionManager cm = new ConnectionManager();
-		cm.publish(bvar);
+		sink(bvar);
 	}
 
 }

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/BaseSummaryTaintWrapperTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/BaseSummaryTaintWrapperTests.java
@@ -51,7 +51,7 @@ public abstract class BaseSummaryTaintWrapperTests {
 	}
 
 	protected void testFlowForMethod(String m, int count) {
-
+		testFlowForMethod(m, count, null);
 	}
 
 	protected void testFlowForMethod(String m, int count, Consumer<InfoflowConfiguration> configCallback) {

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/SummaryTaintWrapperTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/SummaryTaintWrapperTests.java
@@ -341,6 +341,11 @@ public abstract class SummaryTaintWrapperTests extends BaseSummaryTaintWrapperTe
 		testNoFlowForMethod("<soot.jimple.infoflow.test.methodSummary.ApiClassClient: void listIrrelevantItemTest()>");
 	}
 
+	@Test(timeout = 30000)
+	public void testTypeNarrowing() {
+		testFlowForMethod("<soot.jimple.infoflow.test.methodSummary.ApiClassClient: void testTypeNarrowing()>", 1);
+	}
+
 	@Test
 	public void testAllSummaries() throws URISyntaxException, IOException {
 		EagerSummaryProvider provider = new EagerSummaryProvider(TaintWrapperFactory.DEFAULT_SUMMARY_DIR);

--- a/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/SummaryTaintWrapperTests.java
+++ b/soot-infoflow-summaries/test/soot/jimple/infoflow/test/methodSummary/junit/SummaryTaintWrapperTests.java
@@ -338,7 +338,7 @@ public abstract class SummaryTaintWrapperTests extends BaseSummaryTaintWrapperTe
 
 	@Test(timeout = 30000)
 	public void listIrrelevantItemTest() {
-		testFlowForMethod("<soot.jimple.infoflow.test.methodSummary.ApiClassClient: void listIrrelevantItemTest()>", 1);
+		testNoFlowForMethod("<soot.jimple.infoflow.test.methodSummary.ApiClassClient: void listIrrelevantItemTest()>");
 	}
 
 	@Test


### PR DESCRIPTION
Without the fix, the type of the return value of `String.split()` will be refined to `String` (instead of the correct `String[]`) and therefore fails later type checks, leading to false negatives.