### PR TITLE
Prevent singleton from living on forever

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/IccInstrumenter.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/IccInstrumenter.java
@@ -1,6 +1,7 @@
 package soot.jimple.infoflow.android.iccta;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -43,6 +44,8 @@ public class IccInstrumenter implements PreAnalysisHandler {
 	protected final SootMethod smSendMessage;
 	protected final Set<SootMethod> processedMethods = new HashSet<>();
 	protected final MultiMap<Body, Unit> instrumentedUnits = new HashMultiMap<>();
+
+	private Collection<SootClass> handlers;
 
 	public IccInstrumenter(String iccModel, SootClass dummyMainClass,
 			ComponentEntryPointCollection componentToEntryPoint) {
@@ -174,7 +177,8 @@ public class IccInstrumenter implements PreAnalysisHandler {
 						if (callee == smMessengerSend || callee == smSendMessage) {
 							// collect the value for sendMessage()
 							String hc = appClasses.get(stmt.getInvokeExpr().getUseBoxes().get(1).getValue());
-							Set<SootClass> handlers = MessageHandler.v().getAllHandlers();
+							if (handlers == null)
+								handlers = MessageHandler.getAllHandlers();
 							for (SootClass handler : handlers) {
 								// matching the handler and its signature
 								if (hc != null && handlerInner.get(hc) == handler.getName()) {

--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/MessageHandler.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/iccta/MessageHandler.java
@@ -1,46 +1,19 @@
 package soot.jimple.infoflow.android.iccta;
 
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.Collection;
 
 import soot.Scene;
 import soot.SootClass;
 
-public class MessageHandler {
-	private static MessageHandler instance = new MessageHandler();
+public final class MessageHandler {
 
 	private MessageHandler() {
-	};
-
-	public static MessageHandler v() {
-		return instance;
 	}
 
-	private Set<SootClass> handlerImpls = null;
+	public static Collection<SootClass> getAllHandlers() {
+		SootClass handler = Scene.v().getSootClass("android.os.Handler");
+		Collection<SootClass> h = Scene.v().getOrMakeFastHierarchy().getSubclassesOf(handler);
 
-	public Set<SootClass> getAllHandlers() {
-		if (null == handlerImpls) {
-			handlerImpls = new HashSet<SootClass>();
-
-			SootClass handler = Scene.v().getSootClass("android.os.Handler");
-
-			for (Iterator<SootClass> iter = Scene.v().getApplicationClasses().snapshotIterator(); iter.hasNext();) {
-				SootClass sootClass = iter.next();
-
-				SootClass tmpClass =  sootClass;
-
-				while (sootClass != null) {
-
-					if (sootClass.getName().equals(handler.getName())) {
-						handlerImpls.add(tmpClass);
-						break;
-					}
-					sootClass = sootClass.getSuperclassUnsafe();
-				}
-			}
-		}
-
-		return handlerImpls;
+		return h;
 	}
 }


### PR DESCRIPTION
MessageHandler would retain SootClasses that even outlive G.reset(), that can lead to wrong behavior as well as a memory leak.