### PR TITLE
add missing ResType.id getter

### DIFF
--- a/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
+++ b/soot-infoflow-android/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
@@ -377,7 +377,11 @@ public class ARSCFileParser extends AbstractResourceParser {
 	public static class ResType {
 		private int id;
 		private String typeName;
-		private List<ResConfig> configurations = new ArrayList<ResConfig>();
+		private List<ResConfig> configurations = new ArrayList<>();
+
+		public int getId() {
+			return id;
+		}
 
 		public String getTypeName() {
 			return this.typeName;


### PR DESCRIPTION
If you want to access the id and the field is private a getter would be handy...

All the other private fields already have a getter, just the one for id was missing.