### PR TITLE
Add missing case for NewMultiArrayExpr

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/util/BaseSelector.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/util/BaseSelector.java
@@ -54,6 +54,7 @@ public class BaseSelector {
 	 * the operations that are not relevant for analysis like "not" or casts
 	 * are removed - array refs are only removed if explicitly stated
 	 * BinOpExpr are divided into two values
+     * NewMultiArrayExpr are divided into their sizes
 	 * @param val the value which should be pruned
 	 * @param keepArrayRef if false then array refs are pruned to the base array object
 	 * @return one or more values 
@@ -65,6 +66,10 @@ public class BaseSelector {
 			set[0] = expr.getOp1();
 			set[1] = expr.getOp2();
 			return set;
+		}
+        else if (val instanceof NewMultiArrayExpr) {
+			NewMultiArrayExpr expr = (NewMultiArrayExpr) val;
+			return expr.getSizes().toArray(new Value[0]);
 		}
 		else
 			return new Value[] { selectBase(val, keepArrayRef) };


### PR DESCRIPTION
This enables tainted input sizes of multi-dimensional arrays to propagate further, which is already the case for one-dimensional arrays.