### PR TITLE
Improvements on Summary APIs

### DIFF
--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/data/provider/EagerSummaryProvider.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/data/provider/EagerSummaryProvider.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
+import soot.jimple.infoflow.methodSummary.taintWrappers.TaintWrapperFactory;
 import soot.jimple.infoflow.methodSummary.xml.SummaryReader;
 
 /**
@@ -14,6 +15,16 @@ import soot.jimple.infoflow.methodSummary.xml.SummaryReader;
  *
  */
 public class EagerSummaryProvider extends XMLSummaryProvider {
+
+	/**
+	 * Loads a summary from within the StubDroid jar file.
+	 * 
+	 * @throws URISyntaxException
+	 * @throws IOException
+	 */
+	public EagerSummaryProvider() throws URISyntaxException, IOException {
+		this(TaintWrapperFactory.DEFAULT_SUMMARY_DIR);
+	}
 
 	/**
 	 * Loads a summary from a folder within the StubDroid jar file.

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/data/provider/LazySummaryProvider.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/data/provider/LazySummaryProvider.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import soot.jimple.infoflow.collect.ConcurrentHashSet;
 import soot.jimple.infoflow.methodSummary.data.summary.ClassMethodSummaries;
 import soot.jimple.infoflow.methodSummary.data.summary.ClassSummaries;
+import soot.jimple.infoflow.methodSummary.taintWrappers.TaintWrapperFactory;
 
 /**
  * This class loads method summary xml files on demand.
@@ -26,6 +27,16 @@ public class LazySummaryProvider extends XMLSummaryProvider {
 	protected Set<File> files = new HashSet<>();
 	protected Set<Path> pathes = new HashSet<>();
 	protected Set<String> loadableClasses = new ConcurrentHashSet<>();
+
+	/**
+	 * Loads a summary from within the StubDroid jar file.
+	 * 
+	 * @throws URISyntaxException
+	 * @throws IOException
+	 */
+	public LazySummaryProvider() throws URISyntaxException, IOException {
+		this(TaintWrapperFactory.DEFAULT_SUMMARY_DIR);
+	}
 
 	/**
 	 * Loads a summary from a folder within the StubDroid jar file.

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/ReportMissingSummaryWrapper.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/ReportMissingSummaryWrapper.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -31,11 +32,16 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 		super(flows);
 	}
 
-	ConcurrentHashMap<SootClass, AtomicInteger> classSummariesMissing = new ConcurrentHashMap<>();
+	private ConcurrentHashMap<SootClass, AtomicInteger> classSummariesMissing = new ConcurrentHashMap<>();
+	private boolean prettyPrint = false;
+	private boolean showAppClasses = false;
 
 	@Override
 	protected void reportMissingMethod(SootMethod method) {
-		count(method.getDeclaringClass(), classSummariesMissing);
+		SootClass decl = method.getDeclaringClass();
+		if (!showAppClasses && decl.isApplicationClass())
+			return;
+		count(decl, classSummariesMissing);
 	}
 
 	private static <T> void count(T item, Map<T, AtomicInteger> map) {
@@ -47,6 +53,22 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 		}
 
 		ai.incrementAndGet();
+	}
+
+	public void setPrettyPrinting(boolean prettyPrint) {
+		this.prettyPrint = prettyPrint;
+	}
+
+	public boolean isPrettyPrinting() {
+		return prettyPrint;
+	}
+
+	public void setShowApplicationClasses(boolean showAppClasses) {
+		this.showAppClasses = showAppClasses;
+	}
+
+	public boolean isShowingApplicationClasses() {
+		return showAppClasses;
 	}
 
 	public void writeResults(File file) throws IOException, ParserConfigurationException, TransformerException {
@@ -71,6 +93,11 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 		Transformer transformer = transformerFactory.newTransformer();
+
+		if (prettyPrint) {
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+		}
 		DOMSource source = new DOMSource(doc);
 		StreamResult result = new StreamResult(file);
 

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/ReportMissingSummaryWrapper.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/ReportMissingSummaryWrapper.java
@@ -27,6 +27,9 @@ import soot.SootClass;
 import soot.SootMethod;
 import soot.jimple.infoflow.methodSummary.data.provider.IMethodSummaryProvider;
 
+/**
+ * Reports missing summaries by writing the results to a XML file.
+ */
 public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 
 	public ReportMissingSummaryWrapper(IMethodSummaryProvider flows) {
@@ -60,28 +63,56 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 		ai.incrementAndGet();
 	}
 
+	/**
+	 * Sets the pretty printing flag. When enabled, pretty printing
+	 * creates new lines for each XML node, and uses indentation for the XML tree
+	 * @param prettyPrint whether pretty printing should be enabled
+	 */
 	public void setPrettyPrinting(boolean prettyPrint) {
 		this.prettyPrint = prettyPrint;
 	}
 
+	/**
+	 * Pretty printing creates new lines for each XML node, and uses indentation for the XML tree
+	 * @return returns true if enabled, otherwise false
+	 */
 	public boolean isPrettyPrinting() {
 		return prettyPrint;
 	}
 
+	/**
+	 * When the given parameter is true, the class also reports application classes,
+	 * i.e. classes that are part of the application being analyzed.
+	 * @param showAppClasses whether app classes should be shown
+	 */
 	public void setShowApplicationClasses(boolean showAppClasses) {
 		this.showAppClasses = showAppClasses;
 	}
 
+	/**
+	 * Returns whether this class also reports application classes,
+	 * i.e. classes that are part of the application being analyzed
+	 * @return returns true if enabled, otherwise false
+	 */
 	public boolean isShowingApplicationClasses() {
 		return showAppClasses;
 	}
 
-	public boolean isCountMethods() {
-		return countMethods;
-	}
-
+	/**
+	 * If the given parameter is true, this class will report counts
+	 * on a per class and per method basis.
+	 * @param countMethods whether to count methods
+	 */
 	public void setCountMethods(boolean countMethods) {
 		this.countMethods = countMethods;
+	}
+
+	/**
+	 * Returns whether counting methods is enabled
+	 * @return returns true if enabled, otherwise false
+	 */
+	public boolean isCountMethods() {
+		return countMethods;
 	}
 
 	public void writeResults(File file) throws IOException, ParserConfigurationException, TransformerException {

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/ReportMissingSummaryWrapper.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/ReportMissingSummaryWrapper.java
@@ -3,6 +3,7 @@ package soot.jimple.infoflow.methodSummary.taintWrappers;
 import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -33,8 +34,10 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 	}
 
 	private ConcurrentHashMap<SootClass, AtomicInteger> classSummariesMissing = new ConcurrentHashMap<>();
+	private ConcurrentHashMap<SootMethod, AtomicInteger> methodSummariesMissing = new ConcurrentHashMap<>();
 	private boolean prettyPrint = false;
 	private boolean showAppClasses = false;
+	private boolean countMethods = false;
 
 	@Override
 	protected void reportMissingMethod(SootMethod method) {
@@ -42,6 +45,8 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 		if (!showAppClasses && decl.isApplicationClass())
 			return;
 		count(decl, classSummariesMissing);
+		if (countMethods)
+			count(method, methodSummariesMissing);
 	}
 
 	private static <T> void count(T item, Map<T, AtomicInteger> map) {
@@ -71,6 +76,14 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 		return showAppClasses;
 	}
 
+	public boolean isCountMethods() {
+		return countMethods;
+	}
+
+	public void setCountMethods(boolean countMethods) {
+		this.countMethods = countMethods;
+	}
+
 	public void writeResults(File file) throws IOException, ParserConfigurationException, TransformerException {
 		Map<SootClass, Integer> sortedClassSummariesMissing = sortMap(classSummariesMissing);
 		DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
@@ -87,6 +100,23 @@ public class ReportMissingSummaryWrapper extends SummaryTaintWrapper {
 			Element clazz = doc.createElement("Class");
 			clazz.setAttribute("Name", i.getKey().getName());
 			clazz.setAttribute("Count", String.valueOf(i.getValue()));
+			if (countMethods) {
+				SootClass c = i.getKey();
+				Map<SootMethod, AtomicInteger> methods = new HashMap<>(c.getMethods().size());
+				for (SootMethod m : c.getMethods()) {
+					AtomicInteger v = methodSummariesMissing.get(m);
+					if (v != null) {
+						methods.put(m, v);
+					}
+				}
+				sortMap(methods);
+				for (Entry<SootMethod, AtomicInteger> m : methods.entrySet()) {
+					Element method = doc.createElement("Method");
+					method.setAttribute("Name", m.getKey().getSubSignature());
+					method.setAttribute("Count", String.valueOf(m.getValue()));
+					clazz.appendChild(method);
+				}
+			}
 			classes.appendChild(clazz);
 		}
 		rootElement.appendChild(classes);

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/SummaryTaintWrapper.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/SummaryTaintWrapper.java
@@ -1412,9 +1412,9 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 			AccessPathPropagator pparent = propagator.getParent();
 			if (pparent == null) {
 				gap = null;
-				stmt = null;
-				d1 = null;
-				d2 = null;
+				stmt = propagator.getStmt();
+				d1 = propagator.getD1();
+				d2 = propagator.getD2();
 			} else {
 				gap = pparent.getGap();
 				stmt = pparent.getStmt();

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/SummaryTaintWrapper.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/SummaryTaintWrapper.java
@@ -235,7 +235,8 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 			for (AccessPathPropagator propagator : propagators) {
 				// Propagate these taints up. We leave the current gap
 				AccessPathPropagator parent = safePopParent(propagator);
-				GapDefinition parentGap = propagator.getParent() == null ? null : propagator.getParent().getGap();
+				final AccessPathPropagator pparent = propagator.getParent();
+				GapDefinition parentGap = pparent == null ? null : pparent.getGap();
 
 				// Create taints from the abstractions
 				Set<Taint> returnTaints = createTaintFromAccessPathOnReturn(d2.getAccessPath(), (Stmt) u,
@@ -250,10 +251,16 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 				// Create the new propagator, one for every taint
 				Set<AccessPathPropagator> workSet = new HashSet<>();
 				for (Taint returnTaint : returnTaints) {
-					AccessPathPropagator newPropagator = new AccessPathPropagator(returnTaint, parentGap, parent,
-							propagator.getParent() == null ? null : propagator.getParent().getStmt(),
-							propagator.getParent() == null ? null : propagator.getParent().getD1(),
-							propagator.getParent() == null ? null : propagator.getParent().getD2());
+					Stmt stmt = null;
+					Abstraction d1 = null;
+					Abstraction nd2 = null;
+					if (pparent != null) {
+						stmt = pparent.getStmt();
+						d1 = pparent.getD1();
+						nd2 = pparent.getD2();
+					}
+					AccessPathPropagator newPropagator = new AccessPathPropagator(returnTaint, parentGap, parent, stmt,
+							d1, nd2);
 					workSet.add(newPropagator);
 				}
 
@@ -335,9 +342,10 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 			// Get the original call site
 			AccessPathPropagator curProp = propagator;
 			while (curProp != null) {
-				if (curProp.getParent() == null)
+				final AccessPathPropagator parent = curProp.getParent();
+				if (parent == null)
 					return curProp;
-				curProp = curProp.getParent();
+				curProp = parent;
 			}
 			return null;
 		}
@@ -1105,7 +1113,8 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 
 		// We need to pop the last gap element off the stack
 		AccessPathPropagator parent = safePopParent(propagator);
-		GapDefinition gap = propagator.getParent() == null ? null : propagator.getParent().getGap();
+		AccessPathPropagator pparent = propagator.getParent();
+		GapDefinition gap = pparent == null ? null : pparent.getGap();
 
 		// We might already have a summary for the callee
 		Set<AccessPathPropagator> outgoingTaints = null;
@@ -1122,10 +1131,16 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 							propagator.getGap());
 					if (newTaints != null) {
 						for (Taint newTaint : newTaints) {
-							AccessPathPropagator newPropagator = new AccessPathPropagator(newTaint, gap, parent,
-									propagator.getParent() == null ? null : propagator.getParent().getStmt(),
-									propagator.getParent() == null ? null : propagator.getParent().getD1(),
-									propagator.getParent() == null ? null : propagator.getParent().getD2());
+							Stmt nstmt = null;
+							Abstraction d1 = null;
+							Abstraction d2 = null;
+							if (pparent != null) {
+								nstmt = pparent.getStmt();
+								d1 = pparent.getD1();
+								d2 = pparent.getD2();
+							}
+							AccessPathPropagator newPropagator = new AccessPathPropagator(newTaint, gap, parent, nstmt,
+									d1, d2);
 							outgoingTaints.add(newPropagator);
 						}
 					}
@@ -1147,9 +1162,10 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 	}
 
 	protected AccessPathPropagator safePopParent(AccessPathPropagator curPropagator) {
-		if (curPropagator.getParent() == null)
+		AccessPathPropagator parent = curPropagator.getParent();
+		if (parent == null)
 			return null;
-		return curPropagator.getParent().getParent();
+		return parent.getParent();
 	}
 
 	/**
@@ -1382,10 +1398,18 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 			taintGap = null;
 		} else {
 			parent = safePopParent(propagator);
-			gap = propagator.getParent() == null ? null : propagator.getParent().getGap();
-			stmt = propagator.getParent() == null ? propagator.getStmt() : propagator.getParent().getStmt();
-			d1 = propagator.getParent() == null ? propagator.getD1() : propagator.getParent().getD1();
-			d2 = propagator.getParent() == null ? propagator.getD2() : propagator.getParent().getD2();
+			AccessPathPropagator pparent = propagator.getParent();
+			if (pparent == null) {
+				gap = null;
+				stmt = null;
+				d1 = null;
+				d2 = null;
+			} else {
+				gap = pparent.getGap();
+				stmt = pparent.getStmt();
+				d1 = pparent.getD1();
+				d2 = pparent.getD2();
+			}
 			taintGap = propagator.getGap();
 		}
 

--- a/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/SummaryTaintWrapper.java
+++ b/soot-infoflow-summaries/src/soot/jimple/infoflow/methodSummary/taintWrappers/SummaryTaintWrapper.java
@@ -1,5 +1,7 @@
 package soot.jimple.infoflow.methodSummary.taintWrappers;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,6 +62,7 @@ import soot.jimple.infoflow.data.AccessPathFactory;
 import soot.jimple.infoflow.data.ContainerContext;
 import soot.jimple.infoflow.data.SootMethodAndClass;
 import soot.jimple.infoflow.handlers.PreAnalysisHandler;
+import soot.jimple.infoflow.methodSummary.data.provider.EagerSummaryProvider;
 import soot.jimple.infoflow.methodSummary.data.provider.IMethodSummaryProvider;
 import soot.jimple.infoflow.methodSummary.data.sourceSink.AbstractFlowSinkSource;
 import soot.jimple.infoflow.methodSummary.data.sourceSink.ConstraintType;
@@ -360,6 +363,14 @@ public class SummaryTaintWrapper implements IReversibleTaintWrapper, ICollection
 	public SummaryTaintWrapper(IMethodSummaryProvider flows) {
 		this.flows = flows;
 		setContainerStrategyFactory(new DefaultConfigContainerStrategyFactory());
+	}
+
+	/**
+	 * Creates a new instance of the {@link SummaryTaintWrapper} class.
+	 * Uses summaries present within the StubDroid JAR file. 
+	 */
+	public SummaryTaintWrapper() throws URISyntaxException, IOException {
+		this(new EagerSummaryProvider());
 	}
 
 	/**


### PR DESCRIPTION
Simplifying using the default summaries (no-args constructors)
Adding options to ReportMissingSummaryWrapper to not report application classes, set pretty printing and optionally report missing methods within classes
SummaryTaintWrapper: do not call propagator.getParent() over and over; merge multiple same if-statements to one (multiple ternary operators over the same condition)