### PR TITLE
 Refactoring sink propagation rule and rule manager to be more flexible

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/collections/problems/rules/forward/ArrayWithIndexPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/collections/problems/rules/forward/ArrayWithIndexPropagationRule.java
@@ -13,7 +13,6 @@ import soot.jimple.AssignStmt;
 import soot.jimple.LengthExpr;
 import soot.jimple.NewArrayExpr;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.collections.ICollectionsSupport;
 import soot.jimple.infoflow.collections.strategies.containers.IContainerStrategy;
@@ -21,16 +20,11 @@ import soot.jimple.infoflow.collections.util.Tristate;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
 import soot.jimple.infoflow.data.ContainerContext;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.IArrayContextProvider;
 import soot.jimple.infoflow.problems.rules.forward.ArrayPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
 public class ArrayWithIndexPropagationRule extends ArrayPropagationRule implements IArrayContextProvider {
-	public ArrayWithIndexPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/collections/problems/rules/forward/CollectionWrapperPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/collections/problems/rules/forward/CollectionWrapperPropagationRule.java
@@ -9,13 +9,11 @@ import soot.jimple.DefinitionStmt;
 import soot.jimple.InstanceInvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.InfoflowConfiguration.StaticFieldTrackingMode;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.cfg.FlowDroidSourceStatement;
 import soot.jimple.infoflow.collections.ICollectionsSupport;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.forward.WrapperPropagationRule;
 import soot.jimple.infoflow.typing.TypeUtils;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
@@ -26,11 +24,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  * @author Tim Lange
  */
 public class CollectionWrapperPropagationRule extends WrapperPropagationRule {
-
-	public CollectionWrapperPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	/**
 	 * Computes the taints produced by a taint wrapper object

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/AbstractTaintPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/AbstractTaintPropagationRule.java
@@ -13,12 +13,12 @@ import soot.jimple.infoflow.problems.TaintPropagationResults;
  */
 public abstract class AbstractTaintPropagationRule implements ITaintPropagationRule {
 
-	protected final InfoflowManager manager;
-	protected final Abstraction zeroValue;
-	protected final TaintPropagationResults results;
+	protected InfoflowManager manager;
+	protected Abstraction zeroValue;
+	protected TaintPropagationResults results;
 
-	public AbstractTaintPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
+	@Override
+	public void init(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
 		this.manager = manager;
 		this.zeroValue = zeroValue;
 		this.results = results;

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/BackwardPropagationRuleManagerFactory.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/BackwardPropagationRuleManagerFactory.java
@@ -6,7 +6,14 @@ import java.util.List;
 import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.problems.TaintPropagationResults;
-import soot.jimple.infoflow.problems.rules.backward.*;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsArrayPropagationRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsClinitRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsExceptionPropagationRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsImplicitFlowRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsSinkPropagationRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsSourcePropagationRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsStrongUpdatePropagationRule;
+import soot.jimple.infoflow.problems.rules.backward.BackwardsWrapperRule;
 import soot.jimple.infoflow.problems.rules.forward.SkipSystemClassRule;
 import soot.jimple.infoflow.problems.rules.forward.StopAfterFirstKFlowsPropagationRule;
 
@@ -21,29 +28,29 @@ public class BackwardPropagationRuleManagerFactory implements IPropagationRuleMa
 	@Override
 	public PropagationRuleManager createRuleManager(InfoflowManager manager, Abstraction zeroValue,
 			TaintPropagationResults results) {
-		List<ITaintPropagationRule> ruleList = new ArrayList<>();
+		List<Class<? extends ITaintPropagationRule>> ruleList = new ArrayList<>();
 
 		// backwards only
-		ruleList.add(new BackwardsSinkPropagationRule(manager, zeroValue, results));
-		ruleList.add(new BackwardsSourcePropagationRule(manager, zeroValue, results));
-		ruleList.add(new BackwardsClinitRule(manager, zeroValue, results));
-		ruleList.add(new BackwardsStrongUpdatePropagationRule(manager, zeroValue, results));
+		ruleList.add(BackwardsSinkPropagationRule.class);
+		ruleList.add(BackwardsSourcePropagationRule.class);
+		ruleList.add(BackwardsClinitRule.class);
+		ruleList.add(BackwardsStrongUpdatePropagationRule.class);
 		if (manager.getConfig().getEnableExceptionTracking())
-			ruleList.add(new BackwardsExceptionPropagationRule(manager, zeroValue, results));
+			ruleList.add(BackwardsExceptionPropagationRule.class);
 		if (manager.getConfig().getEnableArrayTracking())
-			ruleList.add(new BackwardsArrayPropagationRule(manager, zeroValue, results));
+			ruleList.add(BackwardsArrayPropagationRule.class);
 		if (manager.getTaintWrapper() != null)
-			ruleList.add(new BackwardsWrapperRule(manager, zeroValue, results));
+			ruleList.add(BackwardsWrapperRule.class);
 
 		// shared
-		ruleList.add(new SkipSystemClassRule(manager, zeroValue, results));
+		ruleList.add(SkipSystemClassRule.class);
 		if (manager.getConfig().getStopAfterFirstKFlows() > 0)
-			ruleList.add(new StopAfterFirstKFlowsPropagationRule(manager, zeroValue, results));
+			ruleList.add(StopAfterFirstKFlowsPropagationRule.class);
 
 		if (manager.getConfig().getImplicitFlowMode().trackControlFlowDependencies())
-			ruleList.add(new BackwardsImplicitFlowRule(manager, zeroValue, results));
+			ruleList.add(BackwardsImplicitFlowRule.class);
 
-		return new PropagationRuleManager(manager, zeroValue, results, ruleList.toArray(new ITaintPropagationRule[0]));
+		return new PropagationRuleManager(manager, zeroValue, results, ruleList);
 	}
 
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/DefaultPropagationRuleManagerFactory.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/DefaultPropagationRuleManagerFactory.java
@@ -32,38 +32,38 @@ public class DefaultPropagationRuleManagerFactory implements IPropagationRuleMan
 	@Override
 	public PropagationRuleManager createRuleManager(InfoflowManager manager, Abstraction zeroValue,
 			TaintPropagationResults results) {
-		List<ITaintPropagationRule> ruleList = new ArrayList<>();
+		List<Class<? extends ITaintPropagationRule>> ruleList = new ArrayList<>();
 
-		ruleList.add(new SourcePropagationRule(manager, zeroValue, results));
-		ruleList.add(new SinkPropagationRule(manager, zeroValue, results));
-		ruleList.add(new StaticPropagationRule(manager, zeroValue, results));
+		ruleList.add(SourcePropagationRule.class);
+		ruleList.add(SinkPropagationRule.class);
+		ruleList.add(StaticPropagationRule.class);
 
 		boolean preciseCollectionTrackingEnabled = manager.getConfig()
 				.getPreciseCollectionStrategy() != PreciseCollectionStrategy.NONE;
 		if (manager.getConfig().getEnableArrayTracking()) {
 			if (preciseCollectionTrackingEnabled)
-				ruleList.add(new ArrayWithIndexPropagationRule(manager, zeroValue, results));
+				ruleList.add(ArrayWithIndexPropagationRule.class);
 			else
-				ruleList.add(new ArrayPropagationRule(manager, zeroValue, results));
+				ruleList.add(ArrayPropagationRule.class);
 		}
 		if (manager.getConfig().getEnableExceptionTracking())
-			ruleList.add(new ExceptionPropagationRule(manager, zeroValue, results));
+			ruleList.add(ExceptionPropagationRule.class);
 		if (manager.getTaintWrapper() != null) {
 			if (preciseCollectionTrackingEnabled)
-				ruleList.add(new CollectionWrapperPropagationRule(manager, zeroValue, results));
+				ruleList.add(CollectionWrapperPropagationRule.class);
 			else
-				ruleList.add(new WrapperPropagationRule(manager, zeroValue, results));
+				ruleList.add(WrapperPropagationRule.class);
 		}
 		if (manager.getConfig().getImplicitFlowMode().trackControlFlowDependencies())
-			ruleList.add(new ImplicitPropagtionRule(manager, zeroValue, results));
-		ruleList.add(new StrongUpdatePropagationRule(manager, zeroValue, results));
+			ruleList.add(ImplicitPropagtionRule.class);
+		ruleList.add(StrongUpdatePropagationRule.class);
 		if (manager.getConfig().getEnableTypeChecking())
-			ruleList.add(new TypingPropagationRule(manager, zeroValue, results));
-		ruleList.add(new SkipSystemClassRule(manager, zeroValue, results));
+			ruleList.add(TypingPropagationRule.class);
+		ruleList.add(SkipSystemClassRule.class);
 		if (manager.getConfig().getStopAfterFirstKFlows() > 0)
-			ruleList.add(new StopAfterFirstKFlowsPropagationRule(manager, zeroValue, results));
+			ruleList.add(StopAfterFirstKFlowsPropagationRule.class);
 
-		return new PropagationRuleManager(manager, zeroValue, results, ruleList.toArray(new ITaintPropagationRule[0]));
+		return new PropagationRuleManager(manager, zeroValue, results, ruleList);
 	}
 
 	public PropagationRuleManager createAliasRuleManager(InfoflowManager manager, Abstraction zeroValue) {

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/ITaintPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/ITaintPropagationRule.java
@@ -4,17 +4,30 @@ import java.util.Collection;
 
 import soot.SootMethod;
 import soot.jimple.Stmt;
+import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
+import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
 /**
- * Common interface for taint propagation rules
+ * Common interface for taint propagation rules.
+ * Note that instances of this class are stateful due to the {@link #init() init} method. 
+ * The implementing class should have a public non-argument constructor.
  * 
  * @author Steven Arzt
  *
  */
 public interface ITaintPropagationRule {
-	
+
+	/**
+	 * Initializes the class. Usual implementations of this class save the
+	 * parameters of the class.
+	 * @param manager the infoflow manager
+	 * @param zeroValue the zero value abstraction
+	 * @param results where results should be saved
+	 */
+	public void init(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results);
+
 	/**
 	 * Propagates a flow along a normal statement this is not a call or return
 	 * site
@@ -29,10 +42,8 @@ public interface ITaintPropagationRule {
 	 * killed and nothing shall be propagated onwards
 	 * @return The new abstractions to be propagated to the next statement
 	 */
-	public Collection<Abstraction> propagateNormalFlow(Abstraction d1,
-			Abstraction source, Stmt stmt, Stmt destStmt,
-			ByReferenceBoolean killSource,
-			ByReferenceBoolean killAll);
+	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
+			ByReferenceBoolean killSource, ByReferenceBoolean killAll);
 
 	/**
 	 * Propagates a flow across a call site
@@ -44,10 +55,9 @@ public interface ITaintPropagationRule {
 	 * all taints shall be killed, i.e., nothing shall be propagated
 	 * @return The new abstractions to be propagated to the next statement
 	 */
-	public Collection<Abstraction> propagateCallFlow(Abstraction d1,
-			Abstraction source, Stmt stmt, SootMethod dest,
+	public Collection<Abstraction> propagateCallFlow(Abstraction d1, Abstraction source, Stmt stmt, SootMethod dest,
 			ByReferenceBoolean killAll);
-	
+
 	/**
 	 * Propagates a flow along a the call-to-return edge at a call site
 	 * @param d1 The context abstraction
@@ -59,10 +69,9 @@ public interface ITaintPropagationRule {
 	 * all taints shall be killed, i.e., nothing shall be propagated
 	 * @return The new abstractions to be propagated to the next statement
 	 */
-	public Collection<Abstraction> propagateCallToReturnFlow(Abstraction d1,
-			Abstraction source, Stmt stmt, ByReferenceBoolean killSource,
-			ByReferenceBoolean killAll);
-	
+	public Collection<Abstraction> propagateCallToReturnFlow(Abstraction d1, Abstraction source, Stmt stmt,
+			ByReferenceBoolean killSource, ByReferenceBoolean killAll);
+
 	/**
 	 * Propagates a flow along a the return edge
 	 * @param callerD1s The context abstraction at the caller side
@@ -76,9 +85,7 @@ public interface ITaintPropagationRule {
 	 * all taints shall be killed, i.e., nothing shall be propagated
 	 * @return The new abstractions to be propagated to the next statement
 	 */
-	public Collection<Abstraction> propagateReturnFlow(
-			Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source,
-			Stmt stmt, Stmt retSite, Stmt callSite,
-			ByReferenceBoolean killAll);
-	
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll);
+
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/IdentityPropagationRuleManager.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/IdentityPropagationRuleManager.java
@@ -20,7 +20,7 @@ public class IdentityPropagationRuleManager extends PropagationRuleManager {
 	public static IdentityPropagationRuleManager INSTANCE = new IdentityPropagationRuleManager();
 
 	private IdentityPropagationRuleManager() {
-		super(null, null, null, null);
+		super(null, null, null, (ITaintPropagationRule[]) null);
 	}
 
 	@Override

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/PropagationRuleManager.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/PropagationRuleManager.java
@@ -1,7 +1,9 @@
 package soot.jimple.infoflow.problems.rules;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import soot.SootMethod;
@@ -34,14 +36,75 @@ public class PropagationRuleManager {
 
 		if (rules != null) {
 			for (ITaintPropagationRule rule : rules) {
+				rule.init(manager, zeroValue, results);
 				if (rule instanceof IArrayContextProvider) {
 					arrayRule = (IArrayContextProvider) rule;
-					break;
 				}
 			}
 		}
 		if (arrayRule == null)
 			arrayRule = new DummyArrayContext();
+	}
+
+	public PropagationRuleManager(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results,
+			Class<? extends ITaintPropagationRule>[] rules) {
+		this(manager, zeroValue, results, instantiate(Arrays.asList(rules)));
+	}
+
+	public PropagationRuleManager(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results,
+			List<Class<? extends ITaintPropagationRule>> rules) {
+		this(manager, zeroValue, results, instantiate(rules));
+	}
+
+	private static ITaintPropagationRule[] instantiate(List<Class<? extends ITaintPropagationRule>> rules) {
+		ITaintPropagationRule[] r = new ITaintPropagationRule[rules.size()];
+		for (int i = 0; i < r.length; i++) {
+			Class<? extends ITaintPropagationRule> ruleC = rules.get(i);
+			r[i] = instantiateSingle(ruleC);
+		}
+		return r;
+	}
+
+	private static ITaintPropagationRule instantiateSingle(Class<? extends ITaintPropagationRule> ruleClass) {
+		try {
+			return ruleClass.getDeclaredConstructor().newInstance();
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Could not instantiate rule %s", ruleClass.getName()), e);
+		}
+	}
+
+	/**
+	 * Swaps out an existing rule.
+	 * @param oldRule the class of the old rule implementation
+	 * @param newRule the class of the new implementation
+	 */
+	public void swapRule(Class<? extends ITaintPropagationRule> oldRule,
+			Class<? extends ITaintPropagationRule> newRule) {
+		swapRule(oldRule, instantiateSingle(newRule));
+	}
+
+	/**
+	 * Swaps out an existing rule.
+	 * @param oldRule the class of the old rule implementation
+	 * @param newRule the new implementation
+	 */
+	public void swapRule(Class<? extends ITaintPropagationRule> oldRule, ITaintPropagationRule newRule) {
+		if (rules == null)
+			throw new IllegalStateException("No rules configured");
+
+		for (int i = 0; i < rules.length; i++) {
+			ITaintPropagationRule r = rules[i];
+			if (r.getClass() == oldRule) {
+				r.init(manager, zeroValue, results);
+				if (r instanceof IArrayContextProvider) {
+					arrayRule = (IArrayContextProvider) r;
+				}
+				rules[i] = newRule;
+				return;
+			}
+		}
+		throw new IllegalArgumentException(
+				String.format("Could not find %s in the rules: %s", oldRule.getName(), Arrays.toString(rules)));
 	}
 
 	/**

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsArrayPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsArrayPropagationRule.java
@@ -13,13 +13,11 @@ import soot.jimple.Constant;
 import soot.jimple.LengthExpr;
 import soot.jimple.NewArrayExpr;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
 import soot.jimple.infoflow.data.AccessPath.ArrayTaintType;
 import soot.jimple.infoflow.data.ContainerContext;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.problems.rules.IArrayContextProvider;
 import soot.jimple.infoflow.typing.TypeUtils;
@@ -32,11 +30,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class BackwardsArrayPropagationRule extends AbstractTaintPropagationRule implements IArrayContextProvider {
-
-	public BackwardsArrayPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsClinitRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsClinitRule.java
@@ -1,115 +1,118 @@
 package soot.jimple.infoflow.problems.rules.backward;
 
+import java.util.Collection;
+
 import heros.solver.PathEdge;
-import soot.*;
-import soot.jimple.*;
-import soot.jimple.infoflow.InfoflowManager;
+import soot.SootClass;
+import soot.SootMethod;
+import soot.Unit;
+import soot.Value;
+import soot.jimple.AssignStmt;
+import soot.jimple.NewExpr;
+import soot.jimple.StaticFieldRef;
+import soot.jimple.Stmt;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.BaseSelector;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
-import java.util.Collection;
-
 public class BackwardsClinitRule extends AbstractTaintPropagationRule {
-    public BackwardsClinitRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-        super(manager, zeroValue, results);
-    }
 
-    private void propagateToClinit(Abstraction d1, Abstraction abs, SootMethod callee) {
-        Collection<Unit> startPoints = manager.getICFG().getStartPointsOf(callee);
-        // Most likely |startPoints|=1 but just to be safe
-        for (Unit startPoint : startPoints)
-            manager.getMainSolver().processEdge(new PathEdge<>(d1, startPoint, abs));
-    }
+	private void propagateToClinit(Abstraction d1, Abstraction abs, SootMethod callee) {
+		Collection<Unit> startPoints = manager.getICFG().getStartPointsOf(callee);
+		// Most likely |startPoints|=1 but just to be safe
+		for (Unit startPoint : startPoints)
+			manager.getMainSolver().processEdge(new PathEdge<>(d1, startPoint, abs));
+	}
 
-    private boolean containsStaticField(SootMethod callee, Abstraction abs) {
-        return manager.getICFG().isStaticFieldUsed(callee, abs.getAccessPath().getFirstField())
-                || manager.getICFG().isStaticFieldRead(callee, abs.getAccessPath().getFirstField());
-    }
+	private boolean containsStaticField(SootMethod callee, Abstraction abs) {
+		return manager.getICFG().isStaticFieldUsed(callee, abs.getAccessPath().getFirstField())
+				|| manager.getICFG().isStaticFieldRead(callee, abs.getAccessPath().getFirstField());
+	}
 
-    @Override
-    public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt, ByReferenceBoolean killSource, ByReferenceBoolean killAll) {
-        if (!(stmt instanceof AssignStmt))
-            return null;
-        AssignStmt assignStmt = (AssignStmt) stmt;
+	@Override
+	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
+			ByReferenceBoolean killSource, ByReferenceBoolean killAll) {
+		if (!(stmt instanceof AssignStmt))
+			return null;
+		AssignStmt assignStmt = (AssignStmt) stmt;
 
-        final AccessPath ap = source.getAccessPath();
-        final Aliasing aliasing = getAliasing();
-        if (aliasing == null)
-            return null;
+		final AccessPath ap = source.getAccessPath();
+		final Aliasing aliasing = getAliasing();
+		if (aliasing == null)
+			return null;
 
-        Collection<SootMethod> callees = manager.getICFG().getCalleesOfCallAt(stmt);
-        // Look through all callees and find the clinit call
-        SootMethod callee = callees.stream().filter(c -> c.hasActiveBody()
-                && c.getSubSignature().equals("void <clinit>()")).findAny().orElse(null);
+		Collection<SootMethod> callees = manager.getICFG().getCalleesOfCallAt(stmt);
+		// Look through all callees and find the clinit call
+		SootMethod callee = callees.stream()
+				.filter(c -> c.hasActiveBody() && c.getSubSignature().equals("void <clinit>()")).findAny().orElse(null);
 
-        // no clinit edge -> nothing to do
-        if (callee == null)
-            return null;
+		// no clinit edge -> nothing to do
+		if (callee == null)
+			return null;
 
-        Value leftOp = assignStmt.getLeftOp();
-        boolean leftSideMatches = Aliasing.baseMatches(BaseSelector.selectBase(leftOp, false), source);
-        Value rightOp = assignStmt.getRightOp();
-        Value rightVal = BaseSelector.selectBase(assignStmt.getRightOp(), false);
-        SootClass declaringClassMethod = manager.getICFG().getMethodOf(assignStmt).getDeclaringClass();
+		Value leftOp = assignStmt.getLeftOp();
+		boolean leftSideMatches = Aliasing.baseMatches(BaseSelector.selectBase(leftOp, false), source);
+		Value rightOp = assignStmt.getRightOp();
+		Value rightVal = BaseSelector.selectBase(assignStmt.getRightOp(), false);
+		SootClass declaringClassMethod = manager.getICFG().getMethodOf(assignStmt).getDeclaringClass();
 
-        Abstraction newAbs = null;
-        if (leftSideMatches && rightOp instanceof StaticFieldRef) {
-            SootClass declaringClassOp = ((StaticFieldRef) rightOp).getField().getDeclaringClass();
-            // If the static reference is from the same class
-            // we will at least find the class NewExpr above.
-            // So we wait, maybe we'll find an overwrite
-            if (declaringClassMethod == declaringClassOp)
-                return null;
+		Abstraction newAbs = null;
+		if (leftSideMatches && rightOp instanceof StaticFieldRef) {
+			SootClass declaringClassOp = ((StaticFieldRef) rightOp).getField().getDeclaringClass();
+			// If the static reference is from the same class
+			// we will at least find the class NewExpr above.
+			// So we wait, maybe we'll find an overwrite
+			if (declaringClassMethod == declaringClassOp)
+				return null;
 
-            // This might be the last occurence of the declaring class of the static reference
-            // so we need the visit the clinit method too. The clinit handling is an overapproximation
-            // inherited from the default callgraph algorithm SPARK.
-            AccessPath newAp = manager.getAccessPathFactory().copyWithNewValue(ap, rightVal,
-                    rightVal.getType(), false);
-            newAbs = source.deriveNewAbstraction(newAp, stmt);
-        }
-        else if (ap.isStaticFieldRef() && rightOp instanceof NewExpr) {
-            SootClass declaringClassOp = ((NewExpr) rightOp).getBaseType().getSootClass();
-            // The NewExpr is in its own class, so we find at least another NewExpr of this kind.
-            if (declaringClassMethod == declaringClassOp)
-                return null;
+			// This might be the last occurence of the declaring class of the static reference
+			// so we need the visit the clinit method too. The clinit handling is an overapproximation
+			// inherited from the default callgraph algorithm SPARK.
+			AccessPath newAp = manager.getAccessPathFactory().copyWithNewValue(ap, rightVal, rightVal.getType(), false);
+			newAbs = source.deriveNewAbstraction(newAp, stmt);
+		} else if (ap.isStaticFieldRef() && rightOp instanceof NewExpr) {
+			SootClass declaringClassOp = ((NewExpr) rightOp).getBaseType().getSootClass();
+			// The NewExpr is in its own class, so we find at least another NewExpr of this kind.
+			if (declaringClassMethod == declaringClassOp)
+				return null;
 
-            // In static blocks any statement can be inside also static field of other classes
-            // so we also have to look into it for a possible use.
-            newAbs = source.deriveNewAbstraction(source.getAccessPath(), stmt);
-        }
+			// In static blocks any statement can be inside also static field of other classes
+			// so we also have to look into it for a possible use.
+			newAbs = source.deriveNewAbstraction(source.getAccessPath(), stmt);
+		}
 
-        if (newAbs != null && containsStaticField(callee, newAbs)) {
-            newAbs.setCorrespondingCallSite(assignStmt);
-            propagateToClinit(d1, newAbs, callee);
-        }
+		if (newAbs != null && containsStaticField(callee, newAbs)) {
+			newAbs.setCorrespondingCallSite(assignStmt);
+			propagateToClinit(d1, newAbs, callee);
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public Collection<Abstraction> propagateCallFlow(Abstraction d1, Abstraction source, Stmt stmt, SootMethod dest, ByReferenceBoolean killAll) {
-        return null;
-    }
+	@Override
+	public Collection<Abstraction> propagateCallFlow(Abstraction d1, Abstraction source, Stmt stmt, SootMethod dest,
+			ByReferenceBoolean killAll) {
+		return null;
+	}
 
-    @Override
-    public Collection<Abstraction> propagateCallToReturnFlow(Abstraction d1, Abstraction source, Stmt stmt, ByReferenceBoolean killSource, ByReferenceBoolean killAll) {
-        return null;
-    }
+	@Override
+	public Collection<Abstraction> propagateCallToReturnFlow(Abstraction d1, Abstraction source, Stmt stmt,
+			ByReferenceBoolean killSource, ByReferenceBoolean killAll) {
+		return null;
+	}
 
-    @Override
-    public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
-        // This kills all taints returning from the manual injection of the edge to clinit.
-        Stmt callStmt = source.getCorrespondingCallSite();
-        if (manager.getICFG().getMethodOf(stmt).getSubSignature().equals("void <clinit>()")
-                && callStmt instanceof AssignStmt && ((AssignStmt) callStmt).getRightOp() instanceof StaticFieldRef)
-            killAll.value = true;
+	@Override
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+		// This kills all taints returning from the manual injection of the edge to clinit.
+		Stmt callStmt = source.getCorrespondingCallSite();
+		if (manager.getICFG().getMethodOf(stmt).getSubSignature().equals("void <clinit>()")
+				&& callStmt instanceof AssignStmt && ((AssignStmt) callStmt).getRightOp() instanceof StaticFieldRef)
+			killAll.value = true;
 
-        return null;
-    }
+		return null;
+	}
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsExceptionPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsExceptionPropagationRule.java
@@ -12,11 +12,9 @@ import soot.jimple.CaughtExceptionRef;
 import soot.jimple.IdentityStmt;
 import soot.jimple.Stmt;
 import soot.jimple.ThrowStmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
@@ -27,11 +25,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class BackwardsExceptionPropagationRule extends AbstractTaintPropagationRule {
-
-	public BackwardsExceptionPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsImplicitFlowRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsImplicitFlowRule.java
@@ -20,11 +20,9 @@ import soot.jimple.InvokeExpr;
 import soot.jimple.ReturnStmt;
 import soot.jimple.Stmt;
 import soot.jimple.SwitchStmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.solver.cfg.IInfoflowCFG.UnitContainer;
 import soot.jimple.infoflow.sourcesSinks.manager.IReversibleSourceSinkManager;
@@ -37,10 +35,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  * @author Tim Lange
  */
 public class BackwardsImplicitFlowRule extends AbstractTaintPropagationRule {
-
-	public BackwardsImplicitFlowRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsSinkPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsSinkPropagationRule.java
@@ -2,18 +2,15 @@ package soot.jimple.infoflow.problems.rules.backward;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import soot.SootMethod;
 import soot.Unit;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.cfg.FlowDroidSinkStatement;
 import soot.jimple.infoflow.cfg.FlowDroidSourceStatement;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.sourcesSinks.manager.IReversibleSourceSinkManager;
 import soot.jimple.infoflow.sourcesSinks.manager.SourceInfo;
@@ -27,11 +24,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  * @author Tim Lange
  */
 public class BackwardsSinkPropagationRule extends AbstractTaintPropagationRule {
-
-	public BackwardsSinkPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	private Collection<Abstraction> propagate(Abstraction source, Stmt stmt, ByReferenceBoolean killSource,
 			ByReferenceBoolean killAll) {
@@ -48,11 +40,9 @@ public class BackwardsSinkPropagationRule extends AbstractTaintPropagationRule {
 			if (sinkInfo != null && !sinkInfo.getAccessPaths().isEmpty()) {
 				// Do not introduce taints inside exclusive methods
 				Collection<Unit> callers = manager.getICFG().getCallersOf(manager.getICFG().getMethodOf(stmt));
-				boolean isExclusive = !callers.isEmpty()
-						&& callers.stream().map(u -> (Stmt) u)
-							.allMatch(callerStmt -> callerStmt.containsInvokeExpr()
-													&& manager.getTaintWrapper() != null
-													&& manager.getTaintWrapper().isExclusive(callerStmt, zeroValue));
+				boolean isExclusive = !callers.isEmpty() && callers.stream().map(u -> (Stmt) u)
+						.allMatch(callerStmt -> callerStmt.containsInvokeExpr() && manager.getTaintWrapper() != null
+								&& manager.getTaintWrapper().isExclusive(callerStmt, zeroValue));
 				if (isExclusive)
 					return null;
 

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsSourcePropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsSourcePropagationRule.java
@@ -14,12 +14,10 @@ import soot.jimple.LookupSwitchStmt;
 import soot.jimple.ReturnStmt;
 import soot.jimple.Stmt;
 import soot.jimple.TableSwitchStmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AbstractionAtSink;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.river.IAdditionalFlowSinkPropagationRule;
 import soot.jimple.infoflow.river.SecondarySinkDefinition;
@@ -40,11 +38,6 @@ public class BackwardsSourcePropagationRule extends AbstractTaintPropagationRule
 		implements IAdditionalFlowSinkPropagationRule {
 
 	private boolean killState = false;
-
-	public BackwardsSourcePropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsStrongUpdatePropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsStrongUpdatePropagationRule.java
@@ -20,11 +20,9 @@ import soot.jimple.InstanceFieldRef;
 import soot.jimple.ReturnStmt;
 import soot.jimple.StaticFieldRef;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.typing.TypeUtils;
 import soot.jimple.infoflow.util.BaseSelector;
@@ -37,11 +35,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class BackwardsStrongUpdatePropagationRule extends AbstractTaintPropagationRule {
-
-	public BackwardsStrongUpdatePropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
@@ -93,7 +86,7 @@ public class BackwardsStrongUpdatePropagationRule extends AbstractTaintPropagati
 				}
 			}
 		}
-//		 X.f = y && X.f tainted -> y
+		//		 X.f = y && X.f tainted -> y
 		else if (source.getAccessPath().isStaticFieldRef() && leftOp instanceof StaticFieldRef) {
 			StaticFieldRef leftRef = (StaticFieldRef) leftOp;
 			if (aliasing.mustAlias(leftRef.getField(), source.getAccessPath().getFirstField())) {

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsWrapperRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/backward/BackwardsWrapperRule.java
@@ -22,11 +22,9 @@ import soot.jimple.InstanceInvokeExpr;
 import soot.jimple.InvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.InfoflowConfiguration;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.sourcesSinks.manager.IReversibleSourceSinkManager;
 import soot.jimple.infoflow.sourcesSinks.manager.SinkInfo;
@@ -38,10 +36,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
 import soot.jimple.infoflow.util.preanalyses.SingleLiveVariableAnalysis;
 
 public class BackwardsWrapperRule extends AbstractTaintPropagationRule {
-
-	public BackwardsWrapperRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/ArrayPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/ArrayPropagationRule.java
@@ -14,12 +14,10 @@ import soot.jimple.AssignStmt;
 import soot.jimple.LengthExpr;
 import soot.jimple.NewArrayExpr;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
 import soot.jimple.infoflow.data.AccessPath.ArrayTaintType;
 import soot.jimple.infoflow.data.ContainerContext;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.problems.rules.IArrayContextProvider;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
@@ -31,10 +29,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class ArrayPropagationRule extends AbstractTaintPropagationRule implements IArrayContextProvider {
-
-	public ArrayPropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/ExceptionPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/ExceptionPropagationRule.java
@@ -8,10 +8,8 @@ import soot.jimple.CaughtExceptionRef;
 import soot.jimple.DefinitionStmt;
 import soot.jimple.Stmt;
 import soot.jimple.ThrowStmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
@@ -22,10 +20,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class ExceptionPropagationRule extends AbstractTaintPropagationRule {
-
-	public ExceptionPropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
@@ -65,8 +59,8 @@ public class ExceptionPropagationRule extends AbstractTaintPropagationRule {
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt,
-                                                       Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		// If we throw an exception with a tainted operand, we need to
 		// handle this specially
 		if (stmt instanceof ThrowStmt && retSite instanceof DefinitionStmt) {

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/ImplicitPropagtionRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/ImplicitPropagtionRule.java
@@ -18,13 +18,11 @@ import soot.jimple.LookupSwitchStmt;
 import soot.jimple.ReturnStmt;
 import soot.jimple.Stmt;
 import soot.jimple.TableSwitchStmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.collect.ConcurrentHashSet;
 import soot.jimple.infoflow.collect.MyConcurrentHashMap;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AbstractionAtSink;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.solver.cfg.IInfoflowCFG.UnitContainer;
 import soot.jimple.infoflow.sourcesSinks.manager.SinkInfo;
@@ -39,10 +37,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
 public class ImplicitPropagtionRule extends AbstractTaintPropagationRule {
 
 	private final MyConcurrentHashMap<Unit, Set<Abstraction>> implicitTargets = new MyConcurrentHashMap<Unit, Set<Abstraction>>();
-
-	public ImplicitPropagtionRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
@@ -239,8 +233,8 @@ public class ImplicitPropagtionRule extends AbstractTaintPropagationRule {
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source,
-                                                       Stmt returnStmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt returnStmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		// Are we inside a conditionally-called method?
 		boolean callerD1sConditional = false;
 		for (Abstraction d1 : callerD1s)

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SinkPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SinkPropagationRule.java
@@ -81,8 +81,7 @@ public class SinkPropagationRule extends AbstractTaintPropagationRule {
 				if (aliasing.mayAlias(val, ap.getPlainValue())) {
 					SinkInfo sinkInfo = sourceSinkManager.getSinkInfo(stmt, getManager(), source.getAccessPath());
 					if (sinkInfo != null) {
-						if (!getResults().addResult(new AbstractionAtSink(sinkInfo.getDefinitions(), source, stmt)))
-							killState = true;
+						registerTaintResult(sinkInfo, new AbstractionAtSink(sinkInfo.getDefinitions(), source, stmt));
 					}
 				}
 			}
@@ -151,10 +150,8 @@ public class SinkPropagationRule extends AbstractTaintPropagationRule {
 
 					// If we have already seen the same taint at the same sink, there is no need to
 					// propagate this taint any further.
-					if (sinkInfo != null
-							&& !getResults().addResult(new AbstractionAtSink(sinkInfo.getDefinitions(), source, stmt))) {
-						killState = true;
-					}
+					if (sinkInfo != null)
+						registerTaintResult(sinkInfo, new AbstractionAtSink(sinkInfo.getDefinitions(), source, stmt));
 				}
 			}
 		}
@@ -180,9 +177,8 @@ public class SinkPropagationRule extends AbstractTaintPropagationRule {
 			if (matches && source.isAbstractionActive() && ssm != null && aliasing != null
 					&& aliasing.mayAlias(source.getAccessPath().getPlainValue(), returnStmt.getOp())) {
 				SinkInfo sinkInfo = ssm.getSinkInfo(returnStmt, getManager(), source.getAccessPath());
-				if (sinkInfo != null
-						&& !getResults().addResult(new AbstractionAtSink(sinkInfo.getDefinitions(), source, returnStmt)))
-					killState = true;
+				if (sinkInfo != null)
+					registerTaintResult(sinkInfo, new AbstractionAtSink(sinkInfo.getDefinitions(), source, returnStmt));
 			}
 		}
 
@@ -191,6 +187,21 @@ public class SinkPropagationRule extends AbstractTaintPropagationRule {
 			killAll.value |= killState;
 
 		return null;
+	}
+
+	/**
+	 * Registers a taint result
+	 * @param sinkInfo information about the sink (must not be null)
+	 * @param abstractionAtSink the abstraction at sink (must not be null)
+	 */
+	protected void registerTaintResult(SinkInfo sinkInfo, AbstractionAtSink abstractionAtSink) {
+		boolean continueDataFlow = getResults().addResult(abstractionAtSink);
+		if (!continueDataFlow)
+			setKillState();
+	}
+
+	protected void setKillState() {
+		killState = true;
 	}
 
 }

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SinkPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SinkPropagationRule.java
@@ -12,12 +12,10 @@ import soot.jimple.LookupSwitchStmt;
 import soot.jimple.ReturnStmt;
 import soot.jimple.Stmt;
 import soot.jimple.TableSwitchStmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AbstractionAtSink;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.sourcesSinks.manager.ISourceSinkManager;
 import soot.jimple.infoflow.sourcesSinks.manager.SinkInfo;
@@ -32,10 +30,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
 public class SinkPropagationRule extends AbstractTaintPropagationRule {
 
 	private boolean killState = false;
-
-	public SinkPropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SkipSystemClassRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SkipSystemClassRule.java
@@ -6,9 +6,7 @@ import java.util.Collections;
 import soot.Scene;
 import soot.SootMethod;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
@@ -26,9 +24,7 @@ public class SkipSystemClassRule extends AbstractTaintPropagationRule {
 	private final SootMethod objectGetClass;
 	private final SootMethod threadCons;
 
-	public SkipSystemClassRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-
+	public SkipSystemClassRule() {
 		// Get the system methods
 		this.objectCons = Scene.v().getObjectType().getSootClass().getMethodUnsafe("void <init>()");
 		this.objectClinit = Scene.v().getObjectType().getSootClass().getMethodUnsafe("void <clinit>()");
@@ -83,8 +79,8 @@ public class SkipSystemClassRule extends AbstractTaintPropagationRule {
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt,
-                                                       Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		return null;
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SourcePropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/SourcePropagationRule.java
@@ -7,16 +7,11 @@ import java.util.Set;
 import soot.SootMethod;
 import soot.ValueBox;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.cfg.FlowDroidSinkStatement;
 import soot.jimple.infoflow.cfg.FlowDroidSourceStatement;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
-import soot.jimple.infoflow.sourcesSinks.definitions.ISourceSinkDefinition;
-import soot.jimple.infoflow.sourcesSinks.definitions.MethodSourceSinkDefinition;
-import soot.jimple.infoflow.sourcesSinks.definitions.MethodSourceSinkDefinition.CallType;
 import soot.jimple.infoflow.sourcesSinks.manager.SourceInfo;
 import soot.jimple.infoflow.typing.TypeUtils;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
@@ -28,10 +23,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class SourcePropagationRule extends AbstractTaintPropagationRule {
-
-	public SourcePropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	private Collection<Abstraction> propagate(Abstraction d1, Abstraction source, Stmt stmt,
 			ByReferenceBoolean killSource, ByReferenceBoolean killAll) {
@@ -49,8 +40,8 @@ public class SourcePropagationRule extends AbstractTaintPropagationRule {
 				Set<Abstraction> res = new HashSet<>();
 				for (AccessPath ap : sourceInfo.getAccessPaths()) {
 					// Create the new taint abstraction
-					Abstraction abs = new Abstraction(sourceInfo.getDefinitionsForAccessPath(ap), ap, stmt, sourceInfo.getUserData(),
-							false, false);
+					Abstraction abs = new Abstraction(sourceInfo.getDefinitionsForAccessPath(ap), ap, stmt,
+							sourceInfo.getUserData(), false, false);
 					res.add(abs);
 
 					// Compute the aliases. This is only relevant for variables that are not
@@ -93,8 +84,8 @@ public class SourcePropagationRule extends AbstractTaintPropagationRule {
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt,
-                                                       Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		return null;
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/StaticPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/StaticPropagationRule.java
@@ -6,12 +6,10 @@ import java.util.Collections;
 import soot.SootMethod;
 import soot.jimple.Stmt;
 import soot.jimple.infoflow.InfoflowConfiguration.StaticFieldTrackingMode;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.aliasing.IAliasingStrategy;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
@@ -22,10 +20,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class StaticPropagationRule extends AbstractTaintPropagationRule {
-
-	public StaticPropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
@@ -83,8 +77,8 @@ public class StaticPropagationRule extends AbstractTaintPropagationRule {
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt,
-                                                       Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		// We only handle taints on static variables
 		if (!source.getAccessPath().isStaticFieldRef())
 			return null;

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/StopAfterFirstKFlowsPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/StopAfterFirstKFlowsPropagationRule.java
@@ -4,18 +4,11 @@ import java.util.Collection;
 
 import soot.SootMethod;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
 public class StopAfterFirstKFlowsPropagationRule extends AbstractTaintPropagationRule {
-
-	public StopAfterFirstKFlowsPropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	/**
 	 * Checks whether the data flow analysis must be stopped and sets the kill-flag
@@ -52,8 +45,8 @@ public class StopAfterFirstKFlowsPropagationRule extends AbstractTaintPropagatio
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt,
-                                                       Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		checkStop(killAll);
 		return null;
 	}

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/StrongUpdatePropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/StrongUpdatePropagationRule.java
@@ -11,11 +11,9 @@ import soot.jimple.AssignStmt;
 import soot.jimple.InstanceFieldRef;
 import soot.jimple.StaticFieldRef;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
@@ -26,11 +24,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class StrongUpdatePropagationRule extends AbstractTaintPropagationRule {
-
-	public StrongUpdatePropagationRule(InfoflowManager manager, Abstraction zeroValue,
-			TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/TypingPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/TypingPropagationRule.java
@@ -6,9 +6,7 @@ import soot.SootMethod;
 import soot.jimple.CastExpr;
 import soot.jimple.DefinitionStmt;
 import soot.jimple.Stmt;
-import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.util.ByReferenceBoolean;
 
@@ -19,10 +17,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class TypingPropagationRule extends AbstractTaintPropagationRule {
-
-	public TypingPropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,
@@ -58,8 +52,8 @@ public class TypingPropagationRule extends AbstractTaintPropagationRule {
 	}
 
 	@Override
-	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1, Abstraction source, Stmt stmt,
-                                                       Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
+	public Collection<Abstraction> propagateReturnFlow(Collection<Abstraction> callerD1s, Abstraction calleeD1,
+			Abstraction source, Stmt stmt, Stmt retSite, Stmt callSite, ByReferenceBoolean killAll) {
 		return null;
 	}
 

--- a/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/WrapperPropagationRule.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/problems/rules/forward/WrapperPropagationRule.java
@@ -15,7 +15,6 @@ import soot.jimple.infoflow.aliasing.Aliasing;
 import soot.jimple.infoflow.cfg.FlowDroidSourceStatement;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.data.AccessPath;
-import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.AbstractTaintPropagationRule;
 import soot.jimple.infoflow.taintWrappers.ITaintPropagationWrapper;
 import soot.jimple.infoflow.typing.TypeUtils;
@@ -28,10 +27,6 @@ import soot.jimple.infoflow.util.ByReferenceBoolean;
  *
  */
 public class WrapperPropagationRule extends AbstractTaintPropagationRule {
-
-	public WrapperPropagationRule(InfoflowManager manager, Abstraction zeroValue, TaintPropagationResults results) {
-		super(manager, zeroValue, results);
-	}
 
 	@Override
 	public Collection<Abstraction> propagateNormalFlow(Abstraction d1, Abstraction source, Stmt stmt, Stmt destStmt,

--- a/soot-infoflow/src/soot/jimple/infoflow/river/BackwardNoSinkRuleManagerFactory.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/river/BackwardNoSinkRuleManagerFactory.java
@@ -7,6 +7,7 @@ import soot.jimple.infoflow.InfoflowManager;
 import soot.jimple.infoflow.data.Abstraction;
 import soot.jimple.infoflow.problems.TaintPropagationResults;
 import soot.jimple.infoflow.problems.rules.IPropagationRuleManagerFactory;
+import soot.jimple.infoflow.problems.rules.ITaintPropagationRule;
 import soot.jimple.infoflow.problems.rules.PropagationRuleManager;
 import soot.jimple.infoflow.problems.rules.backward.BackwardsArrayPropagationRule;
 import soot.jimple.infoflow.problems.rules.backward.BackwardsClinitRule;
@@ -15,7 +16,6 @@ import soot.jimple.infoflow.problems.rules.backward.BackwardsImplicitFlowRule;
 import soot.jimple.infoflow.problems.rules.backward.BackwardsSourcePropagationRule;
 import soot.jimple.infoflow.problems.rules.backward.BackwardsStrongUpdatePropagationRule;
 import soot.jimple.infoflow.problems.rules.backward.BackwardsWrapperRule;
-import soot.jimple.infoflow.problems.rules.ITaintPropagationRule;
 import soot.jimple.infoflow.problems.rules.forward.SkipSystemClassRule;
 import soot.jimple.infoflow.problems.rules.forward.StopAfterFirstKFlowsPropagationRule;
 
@@ -33,23 +33,23 @@ public class BackwardNoSinkRuleManagerFactory implements IPropagationRuleManager
 		List<ITaintPropagationRule> ruleList = new ArrayList<>();
 
 		// backwards only
-		ruleList.add(new BackwardsSourcePropagationRule(manager, zeroValue, results));
-		ruleList.add(new BackwardsClinitRule(manager, zeroValue, results));
-		ruleList.add(new BackwardsStrongUpdatePropagationRule(manager, zeroValue, results));
+		ruleList.add(new BackwardsSourcePropagationRule());
+		ruleList.add(new BackwardsClinitRule());
+		ruleList.add(new BackwardsStrongUpdatePropagationRule());
 		if (manager.getConfig().getEnableExceptionTracking())
-			ruleList.add(new BackwardsExceptionPropagationRule(manager, zeroValue, results));
+			ruleList.add(new BackwardsExceptionPropagationRule());
 		if (manager.getConfig().getEnableArrayTracking())
-			ruleList.add(new BackwardsArrayPropagationRule(manager, zeroValue, results));
+			ruleList.add(new BackwardsArrayPropagationRule());
 		if (manager.getTaintWrapper() != null)
-			ruleList.add(new BackwardsWrapperRule(manager, zeroValue, results));
+			ruleList.add(new BackwardsWrapperRule());
 
 		// shared
-		ruleList.add(new SkipSystemClassRule(manager, zeroValue, results));
+		ruleList.add(new SkipSystemClassRule());
 		if (manager.getConfig().getStopAfterFirstKFlows() > 0)
-			ruleList.add(new StopAfterFirstKFlowsPropagationRule(manager, zeroValue, results));
+			ruleList.add(new StopAfterFirstKFlowsPropagationRule());
 
 		if (manager.getConfig().getImplicitFlowMode().trackControlFlowDependencies())
-			ruleList.add(new BackwardsImplicitFlowRule(manager, zeroValue, results));
+			ruleList.add(new BackwardsImplicitFlowRule());
 
 		return new PropagationRuleManager(manager, zeroValue, results, ruleList.toArray(new ITaintPropagationRule[0]));
 	}


### PR DESCRIPTION
Subclasses of ```SinkPropagationRule``` can modify the way taint results are saved by overriding the new ```registerTaintResult``` method.

The rule manager can swap out rules and (optionally) instantiate rules by using ```Class``` objects.