### PR TITLE
fix: add null guards in IFDS solver to prevent NPE crashes on large APKs

### DIFF
--- a/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/IFDSSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/IFDSSolver.java
@@ -617,6 +617,13 @@ public class IFDSSolver<N, D extends FastSolverLinkedNode<D, N>, I extends BiDiI
 	protected void propagate(D sourceVal, N target, D targetVal,
 			/* deliberately exposed to clients */ N relatedCallSite,
 			/* deliberately exposed to clients */ boolean isUnbalancedReturn, ScheduleTarget scheduleTarget) {
+		// Guard against null targetVal — can occur when the alias solver
+		// callback injects an edge with a null abstraction (e.g., after
+		// memory manager pruning). Without this guard, targetVal.getPathLength()
+		// below throws NPE and kills the entire analysis.
+		if (targetVal == null)
+			return;
+
 		// Let the memory manager run
 		if (memoryManager != null) {
 			sourceVal = memoryManager.handleMemoryObject(sourceVal);

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/flowInsensitive/FlowInsensitiveSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/fastSolver/flowInsensitive/FlowInsensitiveSolver.java
@@ -439,7 +439,12 @@ public class FlowInsensitiveSolver<N extends Unit, D extends FastSolverLinkedNod
 					FlowFunction<D> retFunction = flowFunctions.getReturnFlowFunction(c, methodThatNeedsSummary, n,
 							retSiteC);
 					Set<D> targets = computeReturnFlowFunction(retFunction, d1, d2, c, callerSideDs);
-					// for each incoming-call value
+					// Guard against null targets — computeReturnFlowFunction
+					// can return null when the SolverReturnFlowFunction
+					// encounters an edge case (e.g., dead code after pruning).
+					// Without this guard, the for-each loop below throws NPE.
+					if (targets == null || targets.isEmpty())
+						continue;
 					for (Entry<D, D> d1d2entry : entry.getValue().entrySet()) {
 						final D d4 = d1d2entry.getKey();
 						final D predVal = d1d2entry.getValue();
@@ -616,6 +621,12 @@ public class FlowInsensitiveSolver<N extends Unit, D extends FastSolverLinkedNod
 	protected void propagate(D sourceVal, SootMethod target, D targetVal,
 			/* deliberately exposed to clients */ Unit relatedCallSite,
 			/* deliberately exposed to clients */ boolean isUnbalancedReturn, boolean schedule) {
+		// Guard against null targetVal — can occur when the alias solver
+		// callback injects an edge with a null abstraction. Without this
+		// guard, targetVal.getPathLength() below throws NPE.
+		if (targetVal == null)
+			return;
+
 		// Let the memory manager run
 		if (memoryManager != null) {
 			sourceVal = memoryManager.handleMemoryObject(sourceVal);

--- a/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IFDSSolver.java
+++ b/soot-infoflow/src/soot/jimple/infoflow/solver/gcSolver/IFDSSolver.java
@@ -638,6 +638,12 @@ public class IFDSSolver<N, D extends FastSolverLinkedNode<D, N>, I extends BiDiI
 	protected void propagate(D sourceVal, N target, D targetVal,
 			/* deliberately exposed to clients */ N relatedCallSite,
 			/* deliberately exposed to clients */ boolean isUnbalancedReturn) {
+		// Guard against null targetVal — can occur when the alias solver
+		// callback injects an edge with a null abstraction. Without this
+		// guard, targetVal.getPathLength() below throws NPE.
+		if (targetVal == null)
+			return;
+
 		// Let the memory manager run
 		if (memoryManager != null) {
 			sourceVal = memoryManager.handleMemoryObject(sourceVal);


### PR DESCRIPTION
…prevent NPE crashes on large APKs

Two NullPointerExceptions in the IFDS solver crash FlowDroid on large/complex APKs (e.g., 46 MB, 336K+ methods, 6 DEX):

1. targetVal=null NPE in IFDSSolver.propagate(): When the alias solver callback injects an edge with a null abstraction, targetVal.getPathLength() throws NPE and kills the entire analysis. The memoryManager block only checks for null inside its own scope, so when memoryManager is null, targetVal is never validated.

2. targets=null NPE in FlowInsensitiveSolver.processExit(): computeReturnFlowFunction() can return null (the FlowFunction contract allows it), but the main branch of processExit() iterates over the result without a null check. The followReturnsPastSeeds branch already has  @this guard.

Fix: Add early-return null guards before the dereference points in all three solver variants (fastSolver, gcSolver, flowInsensitive).
 Closes secure-software-engineering/FlowDroid#879